### PR TITLE
add support for singleton dimensions

### DIFF
--- a/src/torch_cubic_b_spline_grid/grids.py
+++ b/src/torch_cubic_b_spline_grid/grids.py
@@ -3,7 +3,7 @@ from typing import Tuple, Callable, Union, Sequence, Optional
 
 import torch
 
-from torch_cubic_b_spline_grid.interpolate_grid import (
+from torch_cubic_b_spline_grid.interpolate_grids import (
     interpolate_grid_1d as _interpolate_grid_1d,
     interpolate_grid_2d as _interpolate_grid_2d,
     interpolate_grid_3d as _interpolate_grid_3d,

--- a/src/torch_cubic_b_spline_grid/interpolate_grids.py
+++ b/src/torch_cubic_b_spline_grid/interpolate_grids.py
@@ -1,7 +1,7 @@
 import einops
 import torch
 
-from torch_cubic_b_spline_grid.pad_grid import (
+from torch_cubic_b_spline_grid.pad_grids import (
     pad_grid_1d,
     pad_grid_2d,
     pad_grid_3d,
@@ -13,9 +13,7 @@ from torch_cubic_b_spline_grid.interpolate_pieces import (
     interpolate_pieces_3d,
     interpolate_pieces_4d,
 )
-from torch_cubic_b_spline_grid.utils import \
-    generate_sample_positions_for_padded_grid_1d, find_control_point_idx_1d, \
-    grid_interpolant_to_interpolation_data_1d
+from torch_cubic_b_spline_grid.utils import interpolants_to_interpolation_data_1d
 
 
 def interpolate_grid_1d(grid: torch.Tensor, u: torch.Tensor):
@@ -44,7 +42,7 @@ def interpolate_grid_1d(grid: torch.Tensor, u: torch.Tensor):
     grid = pad_grid_1d(grid)
 
     # find control point indices and interpolation coordinate
-    idx, u = grid_interpolant_to_interpolation_data_1d(u, n_samples=w)
+    idx, u = interpolants_to_interpolation_data_1d(u, n_samples=w)
     control_points = grid[..., idx]  # (c, b, 4)
     control_points = einops.rearrange(control_points, 'c b p -> b c p')
 
@@ -76,8 +74,8 @@ def interpolate_grid_2d(grid: torch.Tensor, u: torch.Tensor):
     grid = pad_grid_2d(grid)
 
     # find control point indices and interpolation coordinate in each dim
-    idx_h, u_h = grid_interpolant_to_interpolation_data_1d(u[:, 0], n_samples=h)
-    idx_w, u_w = grid_interpolant_to_interpolation_data_1d(u[:, 1], n_samples=w)
+    idx_h, u_h = interpolants_to_interpolation_data_1d(u[:, 0], n_samples=h)
+    idx_w, u_w = interpolants_to_interpolation_data_1d(u[:, 1], n_samples=w)
 
     # construct (4, 4) grids of control points and 2D interpolant then interpolate
     idx_h = einops.repeat(idx_h, 'b h -> b h w', w=4)
@@ -113,9 +111,9 @@ def interpolate_grid_3d(grid, u):
     grid = pad_grid_3d(grid)
 
     # find control point indices and interpolation coordinate in each dim
-    idx_d, u_d = grid_interpolant_to_interpolation_data_1d(u[:, 0], n_samples_d)
-    idx_h, u_h = grid_interpolant_to_interpolation_data_1d(u[:, 1], n_samples_h)
-    idx_w, u_w = grid_interpolant_to_interpolation_data_1d(u[:, 2], n_samples_w)
+    idx_d, u_d = interpolants_to_interpolation_data_1d(u[:, 0], n_samples_d)
+    idx_h, u_h = interpolants_to_interpolation_data_1d(u[:, 1], n_samples_h)
+    idx_w, u_w = interpolants_to_interpolation_data_1d(u[:, 2], n_samples_w)
 
     # construct (4, 4, 4) grids of control points and 3D interpolant then interpolate
     idx_d = einops.repeat(idx_d, 'b d -> b d h w', h=4, w=4)
@@ -153,10 +151,10 @@ def interpolate_grid_4d(grid: torch.Tensor, u: torch.Tensor):
     grid = pad_grid_4d(grid)
 
     # find control point indices and interpolation coordinate in each dim
-    idx_t, u_t = grid_interpolant_to_interpolation_data_1d(u[:, 0], n_samples=t)
-    idx_d, u_d = grid_interpolant_to_interpolation_data_1d(u[:, 1], n_samples=d)
-    idx_h, u_h = grid_interpolant_to_interpolation_data_1d(u[:, 2], n_samples=h)
-    idx_w, u_w = grid_interpolant_to_interpolation_data_1d(u[:, 3], n_samples=w)
+    idx_t, u_t = interpolants_to_interpolation_data_1d(u[:, 0], n_samples=t)
+    idx_d, u_d = interpolants_to_interpolation_data_1d(u[:, 1], n_samples=d)
+    idx_h, u_h = interpolants_to_interpolation_data_1d(u[:, 2], n_samples=h)
+    idx_w, u_w = interpolants_to_interpolation_data_1d(u[:, 3], n_samples=w)
 
     # construct (4, 4, 4, 4) grids of control points and 4D interpolant then interpolate
     idx_t = einops.repeat(idx_t, 'b t -> b t d h w', d=4, h=4, w=4)

--- a/src/torch_cubic_b_spline_grid/pad_grids.py
+++ b/src/torch_cubic_b_spline_grid/pad_grids.py
@@ -15,6 +15,11 @@ def pad_grid_1d(grid: torch.Tensor):
     padded_grid: torch.Tensor
         `(..., w+2)` padded array.
     """
+    # remove singleton dimension if necessary
+    w = grid.shape[-1]
+    if w == 1:
+        grid = einops.repeat(grid, '... w -> ... (repeat w)', repeat=2)
+
     # find values for padding at each end of width dim
     start = grid[..., 0] - (grid[..., 1] - grid[..., 0])
     end = grid[..., -1] + (grid[..., -1] - grid[..., -2])
@@ -45,6 +50,10 @@ def pad_grid_2d(grid: torch.Tensor) -> torch.Tensor:
     padded_grid: torch.Tensor
         `(..., h+2, w+2)` padded array.
     """
+    # remove singleton dimension if necessary
+    h = grid.shape[-2]
+    if h == 1:
+        grid = einops.repeat(grid, '... h w -> ... (repeat h) w', repeat=2)
     grid = pad_grid_1d(grid)  # pad width dim (..., h, w+2)
 
     # find values for padding at each end of height dim
@@ -73,6 +82,11 @@ def pad_grid_3d(grid: torch.Tensor) -> torch.Tensor:
     padded_grid: torch.Tensor
         `(..., d+2, h+2, w+2)` padded array.
     """
+    # remove singleton dimension if necessary
+    d = grid.shape[-3]
+    if d == 1:
+        grid = einops.repeat(grid, '... d h w -> ... (repeat d) h w', repeat=2)
+
     # pad in height and width dims
     grid = pad_grid_2d(grid)
 
@@ -100,6 +114,11 @@ def pad_grid_4d(grid: torch.Tensor) -> torch.Tensor:
     padded_grid: torch.Tensor
         `(..., t+2, d+2, h+2, w+2)` grid
     """
+    # remove singleton dimension if necessary
+    t = grid.shape[-4]
+    if t == 1:
+        grid = einops.repeat(grid, '... t d h w -> ... (repeat t) d h w', repeat=2)
+
     # pad in height and width dims
     grid = pad_grid_3d(grid)  # (..., t, d+2, h+2, w+2)
 

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -41,6 +41,14 @@ def test_calling_1d_grid():
         assert torch.allclose(result, expected)
 
 
+def test_1d_grid_with_singleton_dimension():
+    """Test that a 2D grid with a singleton dimension can be used."""
+    # singleton in width dim
+    grid = CubicBSplineGrid1d(resolution=1)
+    result = grid(0.5)
+    assert torch.allclose(result, torch.tensor([0.0]))
+
+
 def test_2d_grid_direct_instantiation():
     grid = CubicBSplineGrid2d()
     assert isinstance(grid, CubicBSplineGrid2d)
@@ -67,6 +75,19 @@ def test_calling_2d_grid():
     for arg in ([0.5, 0.5], torch.tensor([0.5, 0.5])):
         result = grid(arg)
         assert torch.allclose(result, expected)
+
+
+def test_2d_grid_with_singleton_dimension():
+    """Test that a 2D grid with a singleton dimension can be used."""
+    # singleton in width dim
+    grid = CubicBSplineGrid2d(resolution=(2, 1))
+    result = grid([0.5, 0.5])
+    assert torch.allclose(result, torch.tensor([0.0, 0.0]))
+
+    # singleton in height dim
+    grid = CubicBSplineGrid2d(resolution=(1, 2))
+    result = grid([0.5, 0.5])
+    assert torch.allclose(result, torch.tensor([0.0, 0.0]))
 
 
 def test_3d_grid_direct_instantiation():
@@ -97,6 +118,24 @@ def test_calling_3d_grid():
         assert torch.allclose(result, expected)
 
 
+def test_3d_grid_with_singleton_dimension():
+    """Test that a 3D grid with a singleton dimension can be used."""
+    # singleton in width dim
+    grid = CubicBSplineGrid3d(resolution=(2, 2, 1))
+    result = grid([0.5, 0.5, 0.5])
+    assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0]))
+
+    # singleton in height dim
+    grid = CubicBSplineGrid3d(resolution=(2, 1, 2))
+    result = grid([0.5, 0.5, 0.5])
+    assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0]))
+
+    # singleton in depth dim
+    grid = CubicBSplineGrid3d(resolution=(1, 2, 2))
+    result = grid([0.5, 0.5, 0.5])
+    assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0]))
+
+
 def test_4d_grid_direct_instantiation():
     grid = CubicBSplineGrid4d()
     assert isinstance(grid, CubicBSplineGrid4d)
@@ -123,3 +162,31 @@ def test_calling_4d_grid():
     for arg in ([0.5, 0.5, 0.5, 0.5], torch.tensor([0.5, 0.5, 0.5, 0.5])):
         result = grid(arg)
         assert torch.allclose(result, expected)
+
+
+def test_4d_grid_with_singleton_dimension():
+    """Test that a 4D grid with a singleton dimension can be used."""
+    # singleton in width dim
+    grid = CubicBSplineGrid4d(resolution=(2, 2, 2, 1))
+    result = grid([0.5, 0.5, 0.5, 0.5])
+    assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0, 0.0]))
+
+    # singleton in height dim
+    grid = CubicBSplineGrid4d(resolution=(2, 2, 1, 2))
+    result = grid([0.5, 0.5, 0.5, 0.5])
+    assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0, 0.0]))
+
+    # singleton in depth dim
+    grid = CubicBSplineGrid4d(resolution=(2, 1, 2, 2))
+    result = grid([0.5, 0.5, 0.5, 0.5])
+    assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0, 0.0]))
+
+    # singleton in time dim
+    grid = CubicBSplineGrid4d(resolution=(1, 2, 2, 2))
+    result = grid([0.5, 0.5, 0.5, 0.5])
+    assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0, 0.0]))
+
+    # multiple singletons
+    grid = CubicBSplineGrid4d(resolution=(1, 1, 1, 1))
+    result = grid([0.5, 0.5, 0.5, 0.5])
+    assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0, 0.0]))

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -18,7 +18,7 @@ def test_1d_grid_direct_instantiation():
     assert isinstance(grid, CubicBSplineGrid1d)
     assert grid.data.shape == (3, 5)
 
-    grid = CubicBSplineGrid1d(resolution=(5, ), n_channels=3)
+    grid = CubicBSplineGrid1d(resolution=(5,), n_channels=3)
     assert isinstance(grid, CubicBSplineGrid1d)
     assert grid.data.shape == (3, 5)
 
@@ -27,7 +27,7 @@ def test_1d_grid_instantiation_from_existing_data():
     """Test grid instantiation from existing data."""
     grid = CubicBSplineGrid1d.from_grid_data(data=torch.zeros(3, 5))
     assert grid.ndim == 1
-    assert grid.resolution == (5, )
+    assert grid.resolution == (5,)
     assert grid.n_channels == 3
     assert isinstance(grid._data, torch.nn.Parameter)
 

--- a/tests/test_interpolate_grid.py
+++ b/tests/test_interpolate_grid.py
@@ -1,6 +1,6 @@
 import torch
 
-from torch_cubic_b_spline_grid import interpolate_grid
+from torch_cubic_b_spline_grid import interpolate_grids
 
 
 def test_interpolate_grid_1d():

--- a/tests/test_interpolate_grid.py
+++ b/tests/test_interpolate_grid.py
@@ -7,7 +7,7 @@ def test_interpolate_grid_1d():
     """Check that 1d interpolation works as expected."""
     grid = torch.tensor([0, 1, 2, 3, 4, 5]).float()
     u = torch.tensor([0.5])
-    result = interpolate_grid.interpolate_grid_1d(grid, u)
+    result = interpolate_grids.interpolate_grid_1d(grid, u)
     expected = torch.tensor([2.5])
     assert torch.allclose(result, expected)
 
@@ -17,7 +17,7 @@ def test_interpolate_grid_1d_approx():
     control_x = torch.linspace(0, 2 * torch.pi, steps=50)
     control_y = torch.sin(control_x)
     sample_x = torch.linspace(0, 1, steps=1000)
-    sample_y = interpolate_grid.interpolate_grid_1d(control_y, sample_x).squeeze()
+    sample_y = interpolate_grids.interpolate_grid_1d(control_y, sample_x).squeeze()
     ground_truth_y = torch.sin(sample_x * 2 * torch.pi)
     mean_absolute_error = torch.mean(torch.abs(sample_y - ground_truth_y))
     assert mean_absolute_error <= 0.01
@@ -32,7 +32,7 @@ def test_interpolate_grid_2d():
          [12, 13, 14, 15]]
     ).float()
     u = torch.tensor([0.5, 0.5]).view(1, 2)
-    result = interpolate_grid.interpolate_grid_2d(grid, u)
+    result = interpolate_grids.interpolate_grid_2d(grid, u)
     expected = torch.tensor([7.5])
     assert torch.allclose(result, expected)
 
@@ -58,7 +58,7 @@ def test_interpolate_grid_3d():
           [60, 61, 62, 63]]],
     ).float()
     u = torch.tensor([[0.5, 0.5, 0.5]]).view(1, 3)
-    result = interpolate_grid.interpolate_grid_3d(grid, u)
+    result = interpolate_grids.interpolate_grid_3d(grid, u)
     expected = torch.tensor([31.5])
     assert torch.allclose(result, expected)
 
@@ -132,6 +132,6 @@ def test_interpolate_grid_4d():
            [252, 253, 254, 255]]]]
     ).float()
     u = torch.tensor([0.5, 0.5, 0.5, 0.5]).view(1, 4)
-    result = interpolate_grid.interpolate_grid_4d(grid, u)
+    result = interpolate_grids.interpolate_grid_4d(grid, u)
     expected = torch.tensor([127.5])
     assert torch.allclose(result, expected)

--- a/tests/test_pad_grid.py
+++ b/tests/test_pad_grid.py
@@ -1,6 +1,6 @@
 import torch
 
-from torch_cubic_b_spline_grid import pad_grid
+from torch_cubic_b_spline_grid import pad_grids
 
 
 def test_pad_1d():

--- a/tests/test_pad_grid.py
+++ b/tests/test_pad_grid.py
@@ -5,7 +5,7 @@ from torch_cubic_b_spline_grid import pad_grids
 
 def test_pad_1d():
     grid = torch.arange(3)
-    padded_grid = pad_grid.pad_grid_1d(grid)
+    padded_grid = pad_grids.pad_grid_1d(grid)
     expected = torch.tensor([-1, 0, 1, 2, 3])
     assert torch.allclose(padded_grid, expected)
 
@@ -15,7 +15,7 @@ def test_pad_2d():
         [[0, 1],
          [2, 3]]
     )
-    padded_grid = pad_grid.pad_grid_2d(grid)
+    padded_grid = pad_grids.pad_grid_2d(grid)
     expected = torch.tensor(
         [[-3, -2, -1, 0],
          [-1, 0, 1, 2],
@@ -32,7 +32,7 @@ def test_pad_3d():
          [[4, 5],
           [6, 7]]]
     )
-    padded_grid = pad_grid.pad_grid_3d(grid)
+    padded_grid = pad_grids.pad_grid_3d(grid)
     expected = torch.tensor(
         [[[-7, -6, -5, -4],
           [-5, -4, -3, -2],
@@ -68,7 +68,7 @@ def test_pad_4d():
           [[12, 13],
            [14, 15]]]]
     )
-    padded_grid = pad_grid.pad_grid_4d(grid)
+    padded_grid = pad_grids.pad_grid_4d(grid)
     expected = torch.tensor(
         [[[[-15, -14, -13, -12],
            [-13, -12, -11, -10],


### PR DESCRIPTION
Singleton dimensions previously led to an error. Singleton dimensions are now padded to 4 identical elements and interpolated multidimensionally as before. This is not as efficient as squeezing and doing interpolation over less dimensions but involves less index wrangling and I don't expect it to be limiting