### PR TITLE
add support for auto packing/unpacking of stacked coordinates

### DIFF
--- a/src/torch_cubic_b_spline_grid/grids.py
+++ b/src/torch_cubic_b_spline_grid/grids.py
@@ -70,7 +70,7 @@ class CubicBSplineGrid(torch.nn.Module):
         return tuple(self._data.shape[1:])
 
     def _coerce_to_batched_coordinates(self, u: torch.Tensor) -> Tuple[torch.Tensor, ]:
-        u = torch.as_tensor(u, dtype=torch.float32)
+        u = torch.atleast_1d(torch.as_tensor(u, dtype=torch.float32))
         self._input_is_coordinate_like = u.shape[-1] == self.ndim
         if self._input_is_coordinate_like is False and self.ndim == 1:
             u = einops.rearrange(u, '... -> ... 1')  # add singleton coord dimension

--- a/src/torch_cubic_b_spline_grid/grids.py
+++ b/src/torch_cubic_b_spline_grid/grids.py
@@ -1,6 +1,7 @@
 from functools import partial
 from typing import Tuple, Callable, Union, Sequence, Optional
 
+import einops
 import torch
 
 from torch_cubic_b_spline_grid.interpolate_grids import (
@@ -33,11 +34,20 @@ class CubicBSplineGrid(torch.nn.Module):
         self.data = torch.zeros(size=grid_shape)
 
     def forward(self, u: torch.Tensor) -> torch.Tensor:
-        u = self._coerce_coordinates(u)
-        return self._interpolation_function(self._data, u)
+        u = self._coerce_to_batched_coordinates(u)  # (b, d)
+        interpolated = self._interpolation_function(self._data, u)
+        return self._unpack_interpolated_output(interpolated)
 
     @classmethod
     def from_grid_data(cls, data: torch.Tensor):
+        """
+
+        Parameters
+        ----------
+        data: torch.Tensor
+            (c, *grid_dimensions) or (*grid_dimensions) array of multichannel values at
+            each grid point.
+        """
         grid = cls()
         grid.data = data
         return grid
@@ -59,18 +69,28 @@ class CubicBSplineGrid(torch.nn.Module):
     def resolution(self) -> Tuple[int, ...]:
         return tuple(self._data.shape[1:])
 
-    def _coerce_coordinates(self, u: torch.Tensor) -> None:
-        u = torch.atleast_1d(torch.as_tensor(u, dtype=torch.float32))
-        if self.ndim == 1:
-            return u
+    def _coerce_to_batched_coordinates(self, u: torch.Tensor) -> Tuple[torch.Tensor, ]:
+        u = torch.as_tensor(u, dtype=torch.float32)
+        self._input_is_coordinate_like = u.shape[-1] == self.ndim
+        if self._input_is_coordinate_like is False and self.ndim == 1:
+            u = einops.rearrange(u, '... -> ... 1')  # add singleton coord dimension
         else:
-            u = torch.atleast_2d(u)
-            if u.shape[-1] != self.ndim:
-                ndim = u.shape[-1]
-                raise ValueError(
-                    f'Cannot interpolate {self.ndim}D grid with {ndim}D coordinates'
-                )
+            u = torch.atleast_2d(u)  # add batch dimension if missing
+        u, self._packed_shapes = einops.pack([u], pattern='* coords')
+        if u.shape[-1] != self.ndim:
+            ndim = u.shape[-1]
+            raise ValueError(
+                f'Cannot interpolate on a {self.ndim}D grid with {ndim}D coordinates'
+            )
         return u
+
+    def _unpack_interpolated_output(self, interpolated: torch.Tensor) -> torch.Tensor:
+        [interpolated] = einops.unpack(
+            interpolated, packed_shapes=self._packed_shapes, pattern='* coords'
+        )
+        if self._input_is_coordinate_like is False and self.ndim == 1:
+            interpolated = einops.rearrange(interpolated, '... 1 -> ...')
+        return interpolated
 
 
 class CubicBSplineGrid1d(CubicBSplineGrid):

--- a/src/torch_cubic_b_spline_grid/interpolate_grids.py
+++ b/src/torch_cubic_b_spline_grid/interpolate_grids.py
@@ -26,7 +26,7 @@ def interpolate_grid_1d(grid: torch.Tensor, u: torch.Tensor):
     grid: torch.Tensor
         `(c, w)` array of `w` values in `c` channels to be interpolated.
     u: torch.Tensor
-        `(b, )` array of query points in the range `[0, 1]` covering the `w`
+        `(b, 1)` array of query points in the range `[0, 1]` covering the `w`
         dimension of `grid`.
     Returns
     -------
@@ -42,7 +42,7 @@ def interpolate_grid_1d(grid: torch.Tensor, u: torch.Tensor):
     grid = pad_grid_1d(grid)
 
     # find control point indices and interpolation coordinate
-    idx, u = interpolants_to_interpolation_data_1d(u, n_samples=w)
+    idx, u = interpolants_to_interpolation_data_1d(u[:, 0], n_samples=w)
     control_points = grid[..., idx]  # (c, b, 4)
     control_points = einops.rearrange(control_points, 'c b p -> b c p')
 

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -49,6 +49,22 @@ def test_1d_grid_with_singleton_dimension():
     assert torch.allclose(result, torch.tensor([0.0]))
 
 
+def test_calling_1d_grid_with_stacked_coords():
+    """Test calling a 1d grid with a multidimensional array of coordinates."""
+    grid = CubicBSplineGrid1d(resolution=1)
+    h, w = 4, 4
+
+    # no explicit coordinate dimension
+    result = grid(torch.rand(size=(h, w)))
+    assert result.shape == (h, w)
+    assert torch.allclose(result, torch.tensor([0]).float())
+
+    # with explicit coordinate dimension
+    result = grid(torch.rand(size=(h, w, 1)))
+    assert result.shape == (h, w, 1)
+    assert torch.allclose(result, torch.tensor([0]).float())
+
+
 def test_2d_grid_direct_instantiation():
     grid = CubicBSplineGrid2d()
     assert isinstance(grid, CubicBSplineGrid2d)
@@ -90,6 +106,17 @@ def test_2d_grid_with_singleton_dimension():
     assert torch.allclose(result, torch.tensor([0.0, 0.0]))
 
 
+def test_calling_2d_grid_with_stacked_coordinates():
+    """Test calling a 2D grid with stacked coordinates."""
+    grid = CubicBSplineGrid2d(resolution=(2, 2), n_channels=1)
+    result = grid(torch.rand(size=(5, 5, 2)))
+    assert result.shape == (5, 5, 1)
+
+    grid = CubicBSplineGrid2d(resolution=(2, 2), n_channels=2)
+    result = grid(torch.rand(size=(5, 5, 2)))
+    assert result.shape == (5, 5, 2)
+
+
 def test_3d_grid_direct_instantiation():
     grid = CubicBSplineGrid3d()
     assert isinstance(grid, CubicBSplineGrid3d)
@@ -116,6 +143,14 @@ def test_calling_3d_grid():
     for arg in ([0.5, 0.5, 0.5], torch.tensor([0.5, 0.5, 0.5])):
         result = grid(arg)
         assert torch.allclose(result, expected)
+
+
+def test_calling_3d_grid_with_stacked_coordinates():
+    """Test calling 3d grid with stacked coordinates."""
+    grid = CubicBSplineGrid3d()
+    d, h, w = 4, 4, 4
+    result = grid(torch.rand(size=(d, h, w, 3)))
+    assert result.shape == (d, h, w, 1)
 
 
 def test_3d_grid_with_singleton_dimension():
@@ -162,6 +197,14 @@ def test_calling_4d_grid():
     for arg in ([0.5, 0.5, 0.5, 0.5], torch.tensor([0.5, 0.5, 0.5, 0.5])):
         result = grid(arg)
         assert torch.allclose(result, expected)
+
+
+def test_calling_4d_grid_with_stacked_coordinates():
+    """Test calling 3d grid with stacked coordinates."""
+    grid = CubicBSplineGrid4d()
+    t, d, h, w = 2, 4, 4, 4
+    result = grid(torch.rand(size=(t, d, h, w, 4)))
+    assert result.shape == (t, d, h, w, 1)
 
 
 def test_4d_grid_with_singleton_dimension():

--- a/tests/test_interpolate_grid.py
+++ b/tests/test_interpolate_grid.py
@@ -6,18 +6,18 @@ from torch_cubic_b_spline_grid import interpolate_grids
 def test_interpolate_grid_1d():
     """Check that 1d interpolation works as expected."""
     grid = torch.tensor([0, 1, 2, 3, 4, 5]).float()
-    u = torch.tensor([0.5])
+    u = torch.tensor([0.5]).view((1, 1))
     result = interpolate_grids.interpolate_grid_1d(grid, u)
-    expected = torch.tensor([2.5])
+    expected = torch.tensor([[2.5]])
     assert torch.allclose(result, expected)
 
 
 def test_interpolate_grid_1d_approx():
     """Check that 1D interpolation approximates a function."""
-    control_x = torch.linspace(0, 2 * torch.pi, steps=50)
-    control_y = torch.sin(control_x)
-    sample_x = torch.linspace(0, 1, steps=1000)
-    sample_y = interpolate_grids.interpolate_grid_1d(control_y, sample_x).squeeze()
+    grid_x = torch.linspace(0, 2 * torch.pi, steps=50)
+    grid_y = torch.sin(grid_x)
+    sample_x = torch.linspace(0, 1, steps=1000).view((-1, 1))
+    sample_y = interpolate_grids.interpolate_grid_1d(grid_y, sample_x)
     ground_truth_y = torch.sin(sample_x * 2 * torch.pi)
     mean_absolute_error = torch.mean(torch.abs(sample_y - ground_truth_y))
     assert mean_absolute_error <= 0.01


### PR DESCRIPTION
The coordinates passed into the torch modules `CubicBSplineGrid<d>D` previously had to be of shape `(b, n)` - these objects now accept multidimensional stacks of coordinates `(d, h, w, n)`