### PR TITLE
add support for interpolating on grids with Catmull-Rom splines

### DIFF
--- a/src/torch_cubic_b_spline_grid/__init__.py
+++ b/src/torch_cubic_b_spline_grid/__init__.py
@@ -9,11 +9,18 @@ except PackageNotFoundError:
 __author__ = "Alister Burt"
 __email__ = "alisterburt@gmail.com"
 
-from .grids import (
+from .b_spline_grids import (
     CubicBSplineGrid1d,
     CubicBSplineGrid2d,
     CubicBSplineGrid3d,
     CubicBSplineGrid4d,
+)
+
+from .catmull_rom_grids import (
+    CubicCatmullRomGrid1d,
+    CubicCatmullRomGrid2d,
+    CubicCatmullRomGrid3d,
+    CubicCatmullRomGrid4d,
 )
 
 __all__ = [
@@ -21,4 +28,8 @@ __all__ = [
     CubicBSplineGrid2d,
     CubicBSplineGrid3d,
     CubicBSplineGrid4d,
+    CubicCatmullRomGrid1d,
+    CubicCatmullRomGrid2d,
+    CubicCatmullRomGrid3d,
+    CubicCatmullRomGrid4d,
 ]

--- a/src/torch_cubic_b_spline_grid/_base_cubic_grid.py
+++ b/src/torch_cubic_b_spline_grid/_base_cubic_grid.py
@@ -1,21 +1,12 @@
-from functools import partial
-from typing import Tuple, Callable, Union, Sequence, Optional
+from typing import Tuple, Callable, Optional
 
 import einops
 import torch
 
-from torch_cubic_b_spline_grid.interpolate_grids import (
-    interpolate_grid_1d as _interpolate_grid_1d,
-    interpolate_grid_2d as _interpolate_grid_2d,
-    interpolate_grid_3d as _interpolate_grid_3d,
-    interpolate_grid_4d as _interpolate_grid_4d,
-)
 from torch_cubic_b_spline_grid.utils import coerce_to_multichannel_grid
 
-CoordinateLike = Union[float, Sequence[float], torch.Tensor]
 
-
-class CubicBSplineGrid(torch.nn.Module):
+class CubicSplineGrid(torch.nn.Module):
     """Base class for continuous parametrisations of multidimensional spaces."""
     resolution: Tuple[int, ...]
     ndim: int
@@ -91,35 +82,3 @@ class CubicBSplineGrid(torch.nn.Module):
         if self._input_is_coordinate_like is False and self.ndim == 1:
             interpolated = einops.rearrange(interpolated, '... 1 -> ...')
         return interpolated
-
-
-class CubicBSplineGrid1d(CubicBSplineGrid):
-    """Continuous parametrisation of a 1D space with a specific resolution."""
-    ndim: int = 1
-    _interpolation_function: Callable = partial(_interpolate_grid_1d)
-
-    def __init__(
-        self,
-        resolution: Optional[Union[int, Tuple[int]]] = None,
-        n_channels: int = 1):
-        if isinstance(resolution, int):
-            resolution = tuple([resolution])
-        super().__init__(resolution, n_channels)
-
-
-class CubicBSplineGrid2d(CubicBSplineGrid):
-    """Continuous parametrisation of a 2D space with a specific resolution."""
-    ndim: int = 2
-    _interpolation_function: Callable = partial(_interpolate_grid_2d)
-
-
-class CubicBSplineGrid3d(CubicBSplineGrid):
-    """Continuous parametrisation of a 3D space with a specific resolution."""
-    ndim: int = 3
-    _interpolation_function: Callable = partial(_interpolate_grid_3d)
-
-
-class CubicBSplineGrid4d(CubicBSplineGrid):
-    """Continuous parametrisation of a 4D space with a specific resolution."""
-    ndim: int = 4
-    _interpolation_function: Callable = partial(_interpolate_grid_4d)

--- a/src/torch_cubic_b_spline_grid/_constants.py
+++ b/src/torch_cubic_b_spline_grid/_constants.py
@@ -1,0 +1,14 @@
+import torch
+
+# Described in Freya Holmer's video "The Continuity of Splines"
+# https://youtu.be/jvPPXbo87ds?t=3462
+
+CUBIC_B_SPLINE_MATRIX = (1 / 6) * torch.tensor([[1, 4, 1, 0],
+                                                [-3, 0, 3, 0],
+                                                [3, -6, 3, 0],
+                                                [-1, 3, -3, 1]])
+
+CUBIC_CATMULL_ROM_MATRIX = (1 / 2) * torch.tensor([[0, 2, 0, 0],
+                                                   [-1, 0, 1, 0],
+                                                   [2, -5, 4, -1],
+                                                   [-1, 3, -3, 1]])

--- a/src/torch_cubic_b_spline_grid/b_spline_grids.py
+++ b/src/torch_cubic_b_spline_grid/b_spline_grids.py
@@ -1,0 +1,56 @@
+from functools import partial
+from typing import Tuple, Callable, Union, Sequence, Optional
+
+import torch
+
+from torch_cubic_b_spline_grid._base_cubic_grid import CubicSplineGrid
+from torch_cubic_b_spline_grid.interpolate_grids import (
+    interpolate_grid_1d as _interpolate_grid_1d,
+    interpolate_grid_2d as _interpolate_grid_2d,
+    interpolate_grid_3d as _interpolate_grid_3d,
+    interpolate_grid_4d as _interpolate_grid_4d,
+)
+from torch_cubic_b_spline_grid._constants import CUBIC_B_SPLINE_MATRIX
+
+CoordinateLike = Union[float, Sequence[float], torch.Tensor]
+
+
+class CubicBSplineGrid1d(CubicSplineGrid):
+    """Continuous parametrisation of a 1D space with a specific resolution."""
+    ndim: int = 1
+    _interpolation_function: Callable = partial(
+        _interpolate_grid_1d, matrix=CUBIC_B_SPLINE_MATRIX
+    )
+
+    def __init__(
+        self,
+        resolution: Optional[Union[int, Tuple[int]]] = None,
+        n_channels: int = 1
+    ):
+        if isinstance(resolution, int):
+            resolution = tuple([resolution])
+        super().__init__(resolution, n_channels)
+
+
+class CubicBSplineGrid2d(CubicSplineGrid):
+    """Continuous parametrisation of a 2D space with a specific resolution."""
+    ndim: int = 2
+    _interpolation_function: Callable = partial(
+        _interpolate_grid_2d, matrix=CUBIC_B_SPLINE_MATRIX
+    )
+
+
+class CubicBSplineGrid3d(CubicSplineGrid):
+    """Continuous parametrisation of a 3D space with a specific resolution."""
+    ndim: int = 3
+    _interpolation_function: Callable = partial(
+        _interpolate_grid_3d, matrix=CUBIC_B_SPLINE_MATRIX
+    )
+
+
+class CubicBSplineGrid4d(CubicSplineGrid):
+    """Continuous parametrisation of a 4D space with a specific resolution."""
+    ndim: int = 4
+    _interpolation_function: Callable = partial(
+        _interpolate_grid_4d, matrix=CUBIC_B_SPLINE_MATRIX
+    )

--- a/src/torch_cubic_b_spline_grid/catmull_rom_grids.py
+++ b/src/torch_cubic_b_spline_grid/catmull_rom_grids.py
@@ -1,0 +1,56 @@
+from functools import partial
+from typing import Tuple, Callable, Union, Sequence, Optional
+
+import torch
+
+from torch_cubic_b_spline_grid._base_cubic_grid import CubicSplineGrid
+from torch_cubic_b_spline_grid.interpolate_grids import (
+    interpolate_grid_1d as _interpolate_grid_1d,
+    interpolate_grid_2d as _interpolate_grid_2d,
+    interpolate_grid_3d as _interpolate_grid_3d,
+    interpolate_grid_4d as _interpolate_grid_4d,
+)
+from torch_cubic_b_spline_grid._constants import CUBIC_CATMULL_ROM_MATRIX
+
+CoordinateLike = Union[float, Sequence[float], torch.Tensor]
+
+
+class CubicCatmullRomGrid1d(CubicSplineGrid):
+    """Continuous parametrisation of a 1D space with a specific resolution."""
+    ndim: int = 1
+    _interpolation_function: Callable = partial(
+        _interpolate_grid_1d, matrix=CUBIC_CATMULL_ROM_MATRIX
+    )
+
+    def __init__(
+        self,
+        resolution: Optional[Union[int, Tuple[int]]] = None,
+        n_channels: int = 1
+    ):
+        if isinstance(resolution, int):
+            resolution = tuple([resolution])
+        super().__init__(resolution, n_channels)
+
+
+class CubicCatmullRomGrid2d(CubicSplineGrid):
+    """Continuous parametrisation of a 2D space with a specific resolution."""
+    ndim: int = 2
+    _interpolation_function: Callable = partial(
+        _interpolate_grid_2d, matrix=CUBIC_CATMULL_ROM_MATRIX
+    )
+
+
+class CubicCatmullRomGrid3d(CubicSplineGrid):
+    """Continuous parametrisation of a 3D space with a specific resolution."""
+    ndim: int = 3
+    _interpolation_function: Callable = partial(
+        _interpolate_grid_3d, matrix=CUBIC_CATMULL_ROM_MATRIX
+    )
+
+
+class CubicCatmullRomGrid4d(CubicSplineGrid):
+    """Continuous parametrisation of a 4D space with a specific resolution."""
+    ndim: int = 4
+    _interpolation_function: Callable = partial(
+        _interpolate_grid_4d, matrix=CUBIC_CATMULL_ROM_MATRIX
+    )

--- a/src/torch_cubic_b_spline_grid/constants.py
+++ b/src/torch_cubic_b_spline_grid/constants.py
@@ -1,7 +1,0 @@
-import torch
-
-# The Continuity of Splines: https://youtu.be/jvPPXbo87ds?t=3224
-CUBIC_B_SPLINE_MATRIX = (1 / 6) * torch.tensor([[1, 4, 1, 0],
-                                                [-3, 0, 3, 0],
-                                                [3, -6, 3, 0],
-                                                [-1, 3, -3, 1]])

--- a/src/torch_cubic_b_spline_grid/interpolate_grids.py
+++ b/src/torch_cubic_b_spline_grid/interpolate_grids.py
@@ -16,8 +16,8 @@ from torch_cubic_b_spline_grid.interpolate_pieces import (
 from torch_cubic_b_spline_grid.utils import interpolants_to_interpolation_data_1d
 
 
-def interpolate_grid_1d(grid: torch.Tensor, u: torch.Tensor):
-    """Uniform cubic B-spline interpolation on a 1D grid.
+def interpolate_grid_1d(grid: torch.Tensor, u: torch.Tensor, matrix: torch.Tensor):
+    """Uniform cubic spline interpolation on a 1D grid.
 
     The range [0, 1] covers all data points in the 1D grid.
 
@@ -28,10 +28,13 @@ def interpolate_grid_1d(grid: torch.Tensor, u: torch.Tensor):
     u: torch.Tensor
         `(b, 1)` array of query points in the range `[0, 1]` covering the `w`
         dimension of `grid`.
+    matrix: torch.Tensor
+        `(4, 4)` characteristic matrix for the spline.
+
     Returns
     -------
     interpolated: torch.Tensor
-        `(b, c)` array of interpolated values in each channel..
+        `(b, c)` array of interpolated values in each channel.
     """
     if grid.ndim == 1:
         grid = einops.rearrange(grid, 'w -> 1 w')
@@ -42,15 +45,15 @@ def interpolate_grid_1d(grid: torch.Tensor, u: torch.Tensor):
     grid = pad_grid_1d(grid)
 
     # find control point indices and interpolation coordinate
-    idx, u = interpolants_to_interpolation_data_1d(u[:, 0], n_samples=w)
+    idx, t = interpolants_to_interpolation_data_1d(u[:, 0], n_samples=w)
     control_points = grid[..., idx]  # (c, b, 4)
     control_points = einops.rearrange(control_points, 'c b p -> b c p')
 
     # interpolate
-    return interpolate_pieces_1d(control_points, u)
+    return interpolate_pieces_1d(control_points, t, matrix=matrix)
 
 
-def interpolate_grid_2d(grid: torch.Tensor, u: torch.Tensor):
+def interpolate_grid_2d(grid: torch.Tensor, u: torch.Tensor, matrix: torch.Tensor):
     """Uniform cubic B-spline interpolation on a 2D grid.
 
     Parameters
@@ -61,6 +64,8 @@ def interpolate_grid_2d(grid: torch.Tensor, u: torch.Tensor):
         `(b, 2)` array of values in the range `[0, 1]`.
         `[0, 1]` in `u[:, 0]` covers dim -2 (h) of `grid`
         `[0, 1]` in `u[:, 1]` covers dim -1 (w) of `grid`
+    matrix: torch.Tensor
+        `(4, 4)` characteristic matrix for the spline.
 
     Returns
     -------
@@ -74,19 +79,19 @@ def interpolate_grid_2d(grid: torch.Tensor, u: torch.Tensor):
     grid = pad_grid_2d(grid)
 
     # find control point indices and interpolation coordinate in each dim
-    idx_h, u_h = interpolants_to_interpolation_data_1d(u[:, 0], n_samples=h)
-    idx_w, u_w = interpolants_to_interpolation_data_1d(u[:, 1], n_samples=w)
+    idx_h, t_h = interpolants_to_interpolation_data_1d(u[:, 0], n_samples=h)
+    idx_w, t_w = interpolants_to_interpolation_data_1d(u[:, 1], n_samples=w)
 
     # construct (4, 4) grids of control points and 2D interpolant then interpolate
     idx_h = einops.repeat(idx_h, 'b h -> b h w', w=4)
     idx_w = einops.repeat(idx_w, 'b w -> b h w', h=4)
     control_points = grid[..., idx_h, idx_w]  # (c, b, 4, 4)
     control_points = einops.rearrange(control_points, 'c b h w -> b c h w')
-    u = einops.rearrange([u_h, u_w], 'hw b -> b hw')
-    return interpolate_pieces_2d(control_points, u)
+    t = einops.rearrange([t_h, t_w], 'hw b -> b hw')
+    return interpolate_pieces_2d(control_points, t, matrix=matrix)
 
 
-def interpolate_grid_3d(grid, u):
+def interpolate_grid_3d(grid: torch.Tensor, u: torch.Tensor, matrix: torch.Tensor):
     """Uniform cubic B-spline interpolation on a 3D grid.
 
     Parameters
@@ -98,6 +103,8 @@ def interpolate_grid_3d(grid, u):
         [0, 1] in b[:, 0] covers depth dim `d` of `grid`
         [0, 1] in b[:, 1] covers height dim `h` of `grid`
         [0, 1] in b[:, 2] covers width dim `w` of `grid`
+    matrix: torch.Tensor
+        `(4, 4)` characteristic matrix for the spline.
 
     Returns
     -------
@@ -111,9 +118,9 @@ def interpolate_grid_3d(grid, u):
     grid = pad_grid_3d(grid)
 
     # find control point indices and interpolation coordinate in each dim
-    idx_d, u_d = interpolants_to_interpolation_data_1d(u[:, 0], n_samples_d)
-    idx_h, u_h = interpolants_to_interpolation_data_1d(u[:, 1], n_samples_h)
-    idx_w, u_w = interpolants_to_interpolation_data_1d(u[:, 2], n_samples_w)
+    idx_d, t_d = interpolants_to_interpolation_data_1d(u[:, 0], n_samples_d)
+    idx_h, t_h = interpolants_to_interpolation_data_1d(u[:, 1], n_samples_h)
+    idx_w, t_w = interpolants_to_interpolation_data_1d(u[:, 2], n_samples_w)
 
     # construct (4, 4, 4) grids of control points and 3D interpolant then interpolate
     idx_d = einops.repeat(idx_d, 'b d -> b d h w', h=4, w=4)
@@ -121,23 +128,25 @@ def interpolate_grid_3d(grid, u):
     idx_w = einops.repeat(idx_w, 'b w -> b d h w', d=4, h=4)
     control_points = grid[:, idx_d, idx_h, idx_w]  # (c, b, 4, 4, 4)
     control_points = einops.rearrange(control_points, 'c b d h w -> b c d h w')
-    u = einops.rearrange([u_d, u_h, u_w], 'dhw b -> b dhw')
-    return interpolate_pieces_3d(control_points, u)
+    t = einops.rearrange([t_d, t_h, t_w], 'dhw b -> b dhw')
+    return interpolate_pieces_3d(control_points, t, matrix=matrix)
 
 
-def interpolate_grid_4d(grid: torch.Tensor, u: torch.Tensor):
+def interpolate_grid_4d(grid: torch.Tensor, u: torch.Tensor, matrix: torch.Tensor):
     """Uniform cubic B-spline interpolation on a 4D grid.
 
     Parameters
     ----------
     grid: torch.Tensor
-        `(c, t, d, h, w)` multichannel 4D grid.
+        `(c, u, d, h, w)` multichannel 4D grid.
     u: torch.Tensor
         `(b, 4)` array of values in the range [0, 1].
-        [0, 1] in b[:, 0] covers time dim `t` of `grid`
+        [0, 1] in b[:, 0] covers time dim `u` of `grid`
         [0, 1] in b[:, 1] covers depth dim `d` of `grid`
         [0, 1] in b[:, 2] covers height dim `h` of `grid`
         [0, 1] in b[:, 3] covers width dim `w` of `grid`
+    matrix: torch.Tensor
+        `(4, 4)` characteristic matrix for the spline.
 
     Returns
     -------
@@ -151,10 +160,10 @@ def interpolate_grid_4d(grid: torch.Tensor, u: torch.Tensor):
     grid = pad_grid_4d(grid)
 
     # find control point indices and interpolation coordinate in each dim
-    idx_t, u_t = interpolants_to_interpolation_data_1d(u[:, 0], n_samples=t)
-    idx_d, u_d = interpolants_to_interpolation_data_1d(u[:, 1], n_samples=d)
-    idx_h, u_h = interpolants_to_interpolation_data_1d(u[:, 2], n_samples=h)
-    idx_w, u_w = interpolants_to_interpolation_data_1d(u[:, 3], n_samples=w)
+    idx_t, t_t = interpolants_to_interpolation_data_1d(u[:, 0], n_samples=t)
+    idx_d, t_d = interpolants_to_interpolation_data_1d(u[:, 1], n_samples=d)
+    idx_h, t_h = interpolants_to_interpolation_data_1d(u[:, 2], n_samples=h)
+    idx_w, t_w = interpolants_to_interpolation_data_1d(u[:, 3], n_samples=w)
 
     # construct (4, 4, 4, 4) grids of control points and 4D interpolant then interpolate
     idx_t = einops.repeat(idx_t, 'b t -> b t d h w', d=4, h=4, w=4)
@@ -163,5 +172,5 @@ def interpolate_grid_4d(grid: torch.Tensor, u: torch.Tensor):
     idx_w = einops.repeat(idx_w, 'b w -> b t d h w', t=4, d=4, h=4)
     control_points = grid[:, idx_t, idx_d, idx_h, idx_w]  # (c, b, 4, 4, 4, 4)
     control_points = einops.rearrange(control_points, 'c b t d h w -> b c t d h w')
-    u = einops.rearrange([u_t, u_d, u_h, u_w], 'tdhw b -> b tdhw')
-    return interpolate_pieces_4d(control_points, u)
+    t = einops.rearrange([t_t, t_d, t_h, t_w], 'tdhw b -> b tdhw')
+    return interpolate_pieces_4d(control_points, t, matrix=matrix)

--- a/src/torch_cubic_b_spline_grid/interpolate_pieces.py
+++ b/src/torch_cubic_b_spline_grid/interpolate_pieces.py
@@ -2,44 +2,60 @@
 import torch
 import einops
 
-from .constants import CUBIC_B_SPLINE_MATRIX
+from ._constants import CUBIC_B_SPLINE_MATRIX, CUBIC_CATMULL_ROM_MATRIX
 
 
-def interpolate_pieces_1d(control_points: torch.Tensor, u: torch.Tensor):
-    """Batched uniform 1D cubic B-spline interpolation.
+def interpolate_pieces_1d(
+    control_points: torch.Tensor, t: torch.Tensor, matrix: torch.Tensor
+):
+    """Batched uniform 1D cubic spline interpolation.
+
+    ```
+    [0, u, u^2, u^3] * [a00, a01, a02, a03]  * [p0]
+                       [a10, a11, a12, a13]    [p1]
+                       [a20, a21, a22, a23]    [p2]
+                       [a30, a31, a32, a33]    [p3]
+    ```
+    c.f. Freya Holmer - "The Continuity of Splines": https://youtu.be/jvPPXbo87ds?t=3462
 
     Parameters
     ----------
     control_points: torch.Tensor
         `(b, c, 4)` batch of 4 uniformly spaced control points `[p0, p1, p2, p3]`
         in `c` channels.
-    u: torch.Tensor
+    t: torch.Tensor
         `(b, )` batch of interpolants in the range [0, 1] covering the interpolation
         interval between `p1` and `p2`
+    matrix: torch.Tensor
+        `(4, 4)` characteristic matrix for the spline.
 
     Returns
     -------
     interpolated: torch.Tensor
         `(b, c)` array of per-channel interpolants of `control_points` at `u`.
     """
-    u = einops.rearrange([u ** 0, u, u ** 2, u ** 3], 'u b -> b 1 1 u')
+    t = einops.rearrange([t ** 0, t, t ** 2, t ** 3], 'u b -> b 1 1 u')
     control_points = einops.rearrange(control_points, 'b c p -> b c p 1')
-    interpolated = u @ CUBIC_B_SPLINE_MATRIX @ control_points
+    interpolated = t @ matrix @ control_points
     return einops.rearrange(interpolated, 'b c 1 1 -> b c')
 
 
-def interpolate_pieces_2d(control_points: torch.Tensor, u: torch.Tensor):
+def interpolate_pieces_2d(
+    control_points: torch.Tensor, t: torch.Tensor, matrix: torch.Tensor
+):
     """Batched uniform 2D cubic B-spline interpolation.
 
     Parameters
     ----------
-    control_points:
+    control_points: torch.Tensor
         `(b, c, 4, 4)` batch of 2D multichannel grids of uniformly spaced control
         points `[p0, p1, p2, p3]` for cubic B-spline interpolation.
-    u:
+    t: torch.Tensor
         `(b, 2)` batch of values in the range `[0, 1]` defining the position of 2D points
         to be interpolated within the interval `[p1, p2]` along dim 1 and 2 of
         the 2D grid of control points.
+    matrix: torch.Tensor
+        `(4, 4)` characteristic matrix for the spline.
 
     Returns
     -------
@@ -49,21 +65,23 @@ def interpolate_pieces_2d(control_points: torch.Tensor, u: torch.Tensor):
     # extract (b, c, 4) control points at each height along width dim of (h, w) grid
     h0, h1, h2, h3 = einops.rearrange(control_points, 'b c h w -> h b c w')
 
-    # separate t into components along height and width dimensions
-    u_h, u_w = einops.rearrange(u, 'b hw -> hw b')
+    # separate u into components along height and width dimensions
+    t_h, t_w = einops.rearrange(t, 'b hw -> hw b')
 
     # 1d interpolation along width dim at each height
-    p0 = interpolate_pieces_1d(control_points=h0, u=u_w)
-    p1 = interpolate_pieces_1d(control_points=h1, u=u_w)
-    p2 = interpolate_pieces_1d(control_points=h2, u=u_w)
-    p3 = interpolate_pieces_1d(control_points=h3, u=u_w)
+    p0 = interpolate_pieces_1d(control_points=h0, t=t_w, matrix=matrix)
+    p1 = interpolate_pieces_1d(control_points=h1, t=t_w, matrix=matrix)
+    p2 = interpolate_pieces_1d(control_points=h2, t=t_w, matrix=matrix)
+    p3 = interpolate_pieces_1d(control_points=h3, t=t_w, matrix=matrix)
 
     # 1d interpolation of result along height dim
     control_points = einops.rearrange([p0, p1, p2, p3], 'p b c -> b c p')
-    return interpolate_pieces_1d(control_points=control_points, u=u_h)
+    return interpolate_pieces_1d(control_points=control_points, t=t_h, matrix=matrix)
 
 
-def interpolate_pieces_3d(control_points: torch.Tensor, u: torch.Tensor):
+def interpolate_pieces_3d(
+    control_points: torch.Tensor, t: torch.Tensor, matrix: torch.Tensor
+):
     """Batched uniform 3D cubic B-spline interpolation.
 
     Parameters
@@ -71,10 +89,12 @@ def interpolate_pieces_3d(control_points: torch.Tensor, u: torch.Tensor):
     control_points: torch.Tensor
         `(b, c, 4, 4, 4)` batch of `(4, 4, 4)` multichannel grids of uniformly
         spaced control points for cubic B-spline interpolation.
-    u: torch.Tensor
+    t: torch.Tensor
         `(b, 3)` batch of values in the range `[0, 1]` defining the position of 3D
         points to be interpolated within the interval `[p1, p2]` along dim -3,
         -2 and -1 of `control_points`
+    matrix: torch.Tensor
+        `(4, 4)` characteristic matrix for the spline.
 
     Returns
     -------
@@ -85,21 +105,23 @@ def interpolate_pieces_3d(control_points: torch.Tensor, u: torch.Tensor):
     d0, d1, d2, d3 = einops.rearrange(control_points, 'b c d h w -> d b c h w')
 
     # separate u into components along depth and (height, width) dimensions
-    u_d = u[:, 0]
-    u_hw = u[:, [1, 2]]
+    t_d = t[:, 0]
+    t_hw = t[:, [1, 2]]
 
     # 2d interpolation on each (height, width) plane at each depth
-    s0 = interpolate_pieces_2d(control_points=d0, u=u_hw)
-    s1 = interpolate_pieces_2d(control_points=d1, u=u_hw)
-    s2 = interpolate_pieces_2d(control_points=d2, u=u_hw)
-    s3 = interpolate_pieces_2d(control_points=d3, u=u_hw)
+    p0 = interpolate_pieces_2d(control_points=d0, t=t_hw, matrix=matrix)
+    p1 = interpolate_pieces_2d(control_points=d1, t=t_hw, matrix=matrix)
+    p2 = interpolate_pieces_2d(control_points=d2, t=t_hw, matrix=matrix)
+    p3 = interpolate_pieces_2d(control_points=d3, t=t_hw, matrix=matrix)
 
     # 1d interpolation of result along depth dim
-    control_points = einops.rearrange([s0, s1, s2, s3], 'p b c -> b c p')
-    return interpolate_pieces_1d(control_points=control_points, u=u_d)
+    control_points = einops.rearrange([p0, p1, p2, p3], 'p b c -> b c p')
+    return interpolate_pieces_1d(control_points=control_points, t=t_d, matrix=matrix)
 
 
-def interpolate_pieces_4d(control_points: torch.Tensor, u: torch.Tensor):
+def interpolate_pieces_4d(
+    control_points: torch.Tensor, t: torch.Tensor, matrix: torch.Tensor
+):
     """Batched 4D cubic B-spline interpolation.
 
     Parameters
@@ -107,10 +129,12 @@ def interpolate_pieces_4d(control_points: torch.Tensor, u: torch.Tensor):
     control_points: torch.Tensor
         `(b, c, 4, 4, 4, 4)` batch of multichannel `(4, 4, 4, 4)` grids of uniformly
         spaced control points for cubic B-spline interpolation.
-    u: torch.Tensor
+    t: torch.Tensor
         `(b, 4)` batch of values in the range `[0, 1]` defining the position of 4D
         points to be interpolated within the interval `[p1, p2]` along dims -4, -3,
         -2 and -1 of `control_points`.
+    matrix: torch.Tensor
+        `(4, 4)` characteristic matrix for the spline.
 
     Returns
     -------
@@ -118,18 +142,18 @@ def interpolate_pieces_4d(control_points: torch.Tensor, u: torch.Tensor):
         `(b, n)` batch of n-dimensional interpolated values.
     """
     # extract (b, c, 4, 4, 4) 3D control point grids at each point along the time dim
-    t0, t1, t2, t3 = einops.rearrange(control_points, 'b c t d h w -> t b c d h w')
+    t0, t1, t2, t3 = einops.rearrange(control_points, 'b c u d h w -> u b c d h w')
 
     # separate u into components along time and (depth, height, width) dimensions
-    u_t = u[:, 0]
-    u_dhw = u[:, [1, 2, 3]]
+    t_t = t[:, 0]
+    t_dhw = t[:, [1, 2, 3]]
 
     # 3D interpolation on each 3D grid along time dimension
-    s0 = interpolate_pieces_3d(control_points=t0, u=u_dhw)
-    s1 = interpolate_pieces_3d(control_points=t1, u=u_dhw)
-    s2 = interpolate_pieces_3d(control_points=t2, u=u_dhw)
-    s3 = interpolate_pieces_3d(control_points=t3, u=u_dhw)
+    p0 = interpolate_pieces_3d(control_points=t0, t=t_dhw, matrix=matrix)
+    p1 = interpolate_pieces_3d(control_points=t1, t=t_dhw, matrix=matrix)
+    p2 = interpolate_pieces_3d(control_points=t2, t=t_dhw, matrix=matrix)
+    p3 = interpolate_pieces_3d(control_points=t3, t=t_dhw, matrix=matrix)
 
     # 1d interpolation of result along time dim
-    control_points = einops.rearrange([s0, s1, s2, s3], 'p b c -> b c p')
-    return interpolate_pieces_1d(control_points=control_points, u=u_t)
+    control_points = einops.rearrange([p0, p1, p2, p3], 'p b c -> b c p')
+    return interpolate_pieces_1d(control_points=control_points, t=t_t, matrix=matrix)

--- a/src/torch_cubic_b_spline_grid/pad_grids.py
+++ b/src/torch_cubic_b_spline_grid/pad_grids.py
@@ -106,21 +106,21 @@ def pad_grid_4d(grid: torch.Tensor) -> torch.Tensor:
     Parameters
     ----------
     grid: torch.Tensor
-        `(..., t, d, h, w)` array of values to be padded in time, depth, height and
+        `(..., u, d, h, w)` array of values to be padded in time, depth, height and
         width dimensions.
 
     Returns
     -------
     padded_grid: torch.Tensor
-        `(..., t+2, d+2, h+2, w+2)` grid
+        `(..., u+2, d+2, h+2, w+2)` grid
     """
     # remove singleton dimension if necessary
     t = grid.shape[-4]
     if t == 1:
-        grid = einops.repeat(grid, '... t d h w -> ... (repeat t) d h w', repeat=2)
+        grid = einops.repeat(grid, '... u d h w -> ... (repeat u) d h w', repeat=2)
 
     # pad in height and width dims
-    grid = pad_grid_3d(grid)  # (..., t, d+2, h+2, w+2)
+    grid = pad_grid_3d(grid)  # (..., u, d+2, h+2, w+2)
 
     # find values for padding at each end of time dim
     dt_start = grid[..., 1, :, :, :] - grid[..., 0, :, :, :]

--- a/tests/test_grid_optimisation.py
+++ b/tests/test_grid_optimisation.py
@@ -123,7 +123,7 @@ def test_4d_grid_optimisation():
 
     _x = torch.linspace(0, 1, steps=10)
     x = torch.meshgrid(_x, _x, _x, _x, indexing='xy')
-    x = einops.rearrange([*x], 'xyz t d h w -> (t d h w) xyz')
+    x = einops.rearrange([*x], 'xyz u d h w -> (u d h w) xyz')
     ground_truth = f(x)
     prediction = grid(x).squeeze()
     mean_absolute_error = torch.mean(torch.abs(prediction - ground_truth))

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from torch_cubic_b_spline_grid import (
@@ -5,53 +6,72 @@ from torch_cubic_b_spline_grid import (
     CubicBSplineGrid2d,
     CubicBSplineGrid3d,
     CubicBSplineGrid4d,
+    CubicCatmullRomGrid1d,
+    CubicCatmullRomGrid2d,
+    CubicCatmullRomGrid3d,
+    CubicCatmullRomGrid4d,
 )
 
 
-def test_1d_grid_direct_instantiation():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid1d, CubicCatmullRomGrid1d]
+)
+def test_1d_grid_direct_instantiation(grid_cls):
     """Test grid instantiation with different types for resolution argument."""
-    grid = CubicBSplineGrid1d()
-    assert isinstance(grid, CubicBSplineGrid1d)
+    grid = grid_cls()
+    assert isinstance(grid, grid_cls)
     assert grid.data.shape == (1, 2)
 
-    grid = CubicBSplineGrid1d(resolution=5, n_channels=3)
-    assert isinstance(grid, CubicBSplineGrid1d)
+    grid = grid_cls(resolution=5, n_channels=3)
+    assert isinstance(grid, grid_cls)
     assert grid.data.shape == (3, 5)
 
-    grid = CubicBSplineGrid1d(resolution=(5,), n_channels=3)
-    assert isinstance(grid, CubicBSplineGrid1d)
+    grid = grid_cls(resolution=(5,), n_channels=3)
+    assert isinstance(grid, grid_cls)
     assert grid.data.shape == (3, 5)
 
 
-def test_1d_grid_instantiation_from_existing_data():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid1d, CubicCatmullRomGrid1d]
+)
+def test_1d_grid_instantiation_from_existing_data(grid_cls):
     """Test grid instantiation from existing data."""
-    grid = CubicBSplineGrid1d.from_grid_data(data=torch.zeros(3, 5))
+    grid = grid_cls.from_grid_data(data=torch.zeros(3, 5))
     assert grid.ndim == 1
     assert grid.resolution == (5,)
     assert grid.n_channels == 3
     assert isinstance(grid._data, torch.nn.Parameter)
 
 
-def test_calling_1d_grid():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid1d, CubicCatmullRomGrid1d]
+)
+def test_calling_1d_grid(grid_cls):
     """Test calling 1d grid."""
-    grid = CubicBSplineGrid1d()
+    grid = grid_cls()
     expected = torch.tensor([0.])
     for arg in (0.5, [0.5], torch.tensor([0.5])):
         result = grid(arg)
         assert torch.allclose(result, expected)
 
 
-def test_1d_grid_with_singleton_dimension():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid1d, CubicCatmullRomGrid1d]
+)
+def test_1d_grid_with_singleton_dimension(grid_cls):
     """Test that a 2D grid with a singleton dimension can be used."""
     # singleton in width dim
-    grid = CubicBSplineGrid1d(resolution=1)
+    grid = grid_cls(resolution=1)
     result = grid(0.5)
     assert torch.allclose(result, torch.tensor([0.0]))
 
 
-def test_calling_1d_grid_with_stacked_coords():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid1d, CubicCatmullRomGrid1d]
+)
+def test_calling_1d_grid_with_stacked_coords(grid_cls):
     """Test calling a 1d grid with a multidimensional array of coordinates."""
-    grid = CubicBSplineGrid1d(resolution=1)
+    grid = grid_cls(resolution=1)
     h, w = 4, 4
 
     # no explicit coordinate dimension
@@ -65,171 +85,216 @@ def test_calling_1d_grid_with_stacked_coords():
     assert torch.allclose(result, torch.tensor([0]).float())
 
 
-def test_2d_grid_direct_instantiation():
-    grid = CubicBSplineGrid2d()
-    assert isinstance(grid, CubicBSplineGrid2d)
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid2d, CubicCatmullRomGrid2d]
+)
+def test_2d_grid_direct_instantiation(grid_cls):
+    grid = grid_cls()
+    assert isinstance(grid, grid_cls)
     assert grid.data.shape == (1, 2, 2)
 
-    grid = CubicBSplineGrid2d(resolution=(5, 4), n_channels=3)
-    assert isinstance(grid, CubicBSplineGrid2d)
+    grid = grid_cls(resolution=(5, 4), n_channels=3)
+    assert isinstance(grid, grid_cls)
     assert grid.data.shape == (3, 5, 4)
 
 
-def test_2d_grid_instantiation_from_existing_data():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid2d, CubicCatmullRomGrid2d]
+)
+def test_2d_grid_instantiation_from_existing_data(grid_cls):
     """Test grid instantiation from existing data."""
-    grid = CubicBSplineGrid2d.from_grid_data(data=torch.zeros(3, 5, 4))
+    grid = grid_cls.from_grid_data(data=torch.zeros(3, 5, 4))
     assert grid.ndim == 2
     assert grid.resolution == (5, 4)
     assert grid.n_channels == 3
     assert isinstance(grid._data, torch.nn.Parameter)
 
 
-def test_calling_2d_grid():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid2d, CubicCatmullRomGrid2d]
+)
+def test_calling_2d_grid(grid_cls):
     """Test calling 2d grid."""
-    grid = CubicBSplineGrid2d()
+    grid = grid_cls()
     expected = torch.tensor([0., 0.])
     for arg in ([0.5, 0.5], torch.tensor([0.5, 0.5])):
         result = grid(arg)
         assert torch.allclose(result, expected)
 
 
-def test_2d_grid_with_singleton_dimension():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid2d, CubicCatmullRomGrid2d]
+)
+def test_2d_grid_with_singleton_dimension(grid_cls):
     """Test that a 2D grid with a singleton dimension can be used."""
     # singleton in width dim
-    grid = CubicBSplineGrid2d(resolution=(2, 1))
+    grid = grid_cls(resolution=(2, 1))
     result = grid([0.5, 0.5])
     assert torch.allclose(result, torch.tensor([0.0, 0.0]))
 
     # singleton in height dim
-    grid = CubicBSplineGrid2d(resolution=(1, 2))
+    grid = grid_cls(resolution=(1, 2))
     result = grid([0.5, 0.5])
     assert torch.allclose(result, torch.tensor([0.0, 0.0]))
 
 
-def test_calling_2d_grid_with_stacked_coordinates():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid2d, CubicCatmullRomGrid2d]
+)
+def test_calling_2d_grid_with_stacked_coordinates(grid_cls):
     """Test calling a 2D grid with stacked coordinates."""
-    grid = CubicBSplineGrid2d(resolution=(2, 2), n_channels=1)
+    grid = grid_cls(resolution=(2, 2), n_channels=1)
     result = grid(torch.rand(size=(5, 5, 2)))
     assert result.shape == (5, 5, 1)
 
-    grid = CubicBSplineGrid2d(resolution=(2, 2), n_channels=2)
+    grid = grid_cls(resolution=(2, 2), n_channels=2)
     result = grid(torch.rand(size=(5, 5, 2)))
     assert result.shape == (5, 5, 2)
 
 
-def test_3d_grid_direct_instantiation():
-    grid = CubicBSplineGrid3d()
-    assert isinstance(grid, CubicBSplineGrid3d)
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid3d, CubicCatmullRomGrid3d]
+)
+def test_3d_grid_direct_instantiation(grid_cls):
+    grid = grid_cls()
+    assert isinstance(grid, grid_cls)
     assert grid.data.shape == (1, 2, 2, 2)
 
-    grid = CubicBSplineGrid3d(resolution=(5, 4, 3), n_channels=2)
-    assert isinstance(grid, CubicBSplineGrid3d)
+    grid = grid_cls(resolution=(5, 4, 3), n_channels=2)
+    assert isinstance(grid, grid_cls)
     assert grid.data.shape == (2, 5, 4, 3)
 
 
-def test_3d_grid_instantiation_from_existing_data():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid3d, CubicCatmullRomGrid3d]
+)
+def test_3d_grid_instantiation_from_existing_data(grid_cls):
     """Test grid instantiation from existing data."""
-    grid = CubicBSplineGrid3d.from_grid_data(data=torch.zeros(2, 5, 4, 3))
+    grid = grid_cls.from_grid_data(data=torch.zeros(2, 5, 4, 3))
     assert grid.ndim == 3
     assert grid.resolution == (5, 4, 3)
     assert grid.n_channels == 2
     assert isinstance(grid._data, torch.nn.Parameter)
 
 
-def test_calling_3d_grid():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid3d, CubicCatmullRomGrid3d]
+)
+def test_calling_3d_grid(grid_cls):
     """Test calling 3d grid."""
-    grid = CubicBSplineGrid3d()
+    grid = grid_cls()
     expected = torch.tensor([0., 0., 0.])
     for arg in ([0.5, 0.5, 0.5], torch.tensor([0.5, 0.5, 0.5])):
         result = grid(arg)
         assert torch.allclose(result, expected)
 
 
-def test_calling_3d_grid_with_stacked_coordinates():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid3d, CubicCatmullRomGrid3d]
+)
+def test_calling_3d_grid_with_stacked_coordinates(grid_cls):
     """Test calling 3d grid with stacked coordinates."""
-    grid = CubicBSplineGrid3d()
+    grid = grid_cls()
     d, h, w = 4, 4, 4
     result = grid(torch.rand(size=(d, h, w, 3)))
     assert result.shape == (d, h, w, 1)
 
 
-def test_3d_grid_with_singleton_dimension():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid3d, CubicCatmullRomGrid3d]
+)
+def test_3d_grid_with_singleton_dimension(grid_cls):
     """Test that a 3D grid with a singleton dimension can be used."""
     # singleton in width dim
-    grid = CubicBSplineGrid3d(resolution=(2, 2, 1))
+    grid = grid_cls(resolution=(2, 2, 1))
     result = grid([0.5, 0.5, 0.5])
     assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0]))
 
     # singleton in height dim
-    grid = CubicBSplineGrid3d(resolution=(2, 1, 2))
+    grid = grid_cls(resolution=(2, 1, 2))
     result = grid([0.5, 0.5, 0.5])
     assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0]))
 
     # singleton in depth dim
-    grid = CubicBSplineGrid3d(resolution=(1, 2, 2))
+    grid = grid_cls(resolution=(1, 2, 2))
     result = grid([0.5, 0.5, 0.5])
     assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0]))
 
 
-def test_4d_grid_direct_instantiation():
-    grid = CubicBSplineGrid4d()
-    assert isinstance(grid, CubicBSplineGrid4d)
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid4d, CubicCatmullRomGrid4d]
+)
+def test_4d_grid_direct_instantiation(grid_cls):
+    grid = grid_cls()
+    assert isinstance(grid, grid_cls)
     assert grid.data.shape == (1, 2, 2, 2, 2)
 
-    grid = CubicBSplineGrid4d(resolution=(6, 5, 4, 3), n_channels=2)
-    assert isinstance(grid, CubicBSplineGrid4d)
+    grid = grid_cls(resolution=(6, 5, 4, 3), n_channels=2)
+    assert isinstance(grid, grid_cls)
     assert grid.data.shape == (2, 6, 5, 4, 3)
 
 
-def test_4d_grid_instantiation_from_existing_data():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid4d, CubicCatmullRomGrid4d]
+)
+def test_4d_grid_instantiation_from_existing_data(grid_cls):
     """Test grid instantiation from existing data."""
-    grid = CubicBSplineGrid4d.from_grid_data(data=torch.zeros(2, 6, 5, 4, 3))
+    grid = grid_cls.from_grid_data(data=torch.zeros(2, 6, 5, 4, 3))
     assert grid.ndim == 4
     assert grid.resolution == (6, 5, 4, 3)
     assert grid.n_channels == 2
     assert isinstance(grid._data, torch.nn.Parameter)
 
 
-def test_calling_4d_grid():
-    """Test calling 3d grid."""
-    grid = CubicBSplineGrid4d()
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid4d, CubicCatmullRomGrid4d]
+)
+def test_calling_4d_grid(grid_cls):
+    """Test calling 4d grid."""
+    grid = grid_cls()
     expected = torch.tensor([0., 0., 0., 0.])
     for arg in ([0.5, 0.5, 0.5, 0.5], torch.tensor([0.5, 0.5, 0.5, 0.5])):
         result = grid(arg)
         assert torch.allclose(result, expected)
 
 
-def test_calling_4d_grid_with_stacked_coordinates():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid4d, CubicCatmullRomGrid4d]
+)
+def test_calling_4d_grid_with_stacked_coordinates(grid_cls):
     """Test calling 3d grid with stacked coordinates."""
-    grid = CubicBSplineGrid4d()
+    grid = grid_cls()
     t, d, h, w = 2, 4, 4, 4
     result = grid(torch.rand(size=(t, d, h, w, 4)))
     assert result.shape == (t, d, h, w, 1)
 
 
-def test_4d_grid_with_singleton_dimension():
+@pytest.mark.parametrize(
+    'grid_cls', [CubicBSplineGrid4d, CubicCatmullRomGrid4d]
+)
+def test_4d_grid_with_singleton_dimension(grid_cls):
     """Test that a 4D grid with a singleton dimension can be used."""
     # singleton in width dim
-    grid = CubicBSplineGrid4d(resolution=(2, 2, 2, 1))
+    grid = grid_cls(resolution=(2, 2, 2, 1))
     result = grid([0.5, 0.5, 0.5, 0.5])
     assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0, 0.0]))
 
     # singleton in height dim
-    grid = CubicBSplineGrid4d(resolution=(2, 2, 1, 2))
+    grid = grid_cls(resolution=(2, 2, 1, 2))
     result = grid([0.5, 0.5, 0.5, 0.5])
     assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0, 0.0]))
 
     # singleton in depth dim
-    grid = CubicBSplineGrid4d(resolution=(2, 1, 2, 2))
+    grid = grid_cls(resolution=(2, 1, 2, 2))
     result = grid([0.5, 0.5, 0.5, 0.5])
     assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0, 0.0]))
 
     # singleton in time dim
-    grid = CubicBSplineGrid4d(resolution=(1, 2, 2, 2))
+    grid = grid_cls(resolution=(1, 2, 2, 2))
     result = grid([0.5, 0.5, 0.5, 0.5])
     assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0, 0.0]))
 
     # multiple singletons
-    grid = CubicBSplineGrid4d(resolution=(1, 1, 1, 1))
+    grid = grid_cls(resolution=(1, 1, 1, 1))
     result = grid([0.5, 0.5, 0.5, 0.5])
     assert torch.allclose(result, torch.tensor([0.0, 0.0, 0.0, 0.0]))

--- a/tests/test_interpolate_grid.py
+++ b/tests/test_interpolate_grid.py
@@ -1,13 +1,16 @@
 import torch
 
 from torch_cubic_b_spline_grid import interpolate_grids
+from torch_cubic_b_spline_grid._constants import CUBIC_B_SPLINE_MATRIX
 
 
 def test_interpolate_grid_1d():
     """Check that 1d interpolation works as expected."""
     grid = torch.tensor([0, 1, 2, 3, 4, 5]).float()
     u = torch.tensor([0.5]).view((1, 1))
-    result = interpolate_grids.interpolate_grid_1d(grid, u)
+    result = interpolate_grids.interpolate_grid_1d(
+        grid, u, matrix=CUBIC_B_SPLINE_MATRIX
+    )
     expected = torch.tensor([[2.5]])
     assert torch.allclose(result, expected)
 
@@ -17,7 +20,9 @@ def test_interpolate_grid_1d_approx():
     grid_x = torch.linspace(0, 2 * torch.pi, steps=50)
     grid_y = torch.sin(grid_x)
     sample_x = torch.linspace(0, 1, steps=1000).view((-1, 1))
-    sample_y = interpolate_grids.interpolate_grid_1d(grid_y, sample_x)
+    sample_y = interpolate_grids.interpolate_grid_1d(
+        grid_y, sample_x, matrix=CUBIC_B_SPLINE_MATRIX
+    )
     ground_truth_y = torch.sin(sample_x * 2 * torch.pi)
     mean_absolute_error = torch.mean(torch.abs(sample_y - ground_truth_y))
     assert mean_absolute_error <= 0.01
@@ -32,7 +37,9 @@ def test_interpolate_grid_2d():
          [12, 13, 14, 15]]
     ).float()
     u = torch.tensor([0.5, 0.5]).view(1, 2)
-    result = interpolate_grids.interpolate_grid_2d(grid, u)
+    result = interpolate_grids.interpolate_grid_2d(
+        grid, u, matrix=CUBIC_B_SPLINE_MATRIX
+    )
     expected = torch.tensor([7.5])
     assert torch.allclose(result, expected)
 
@@ -58,7 +65,8 @@ def test_interpolate_grid_3d():
           [60, 61, 62, 63]]],
     ).float()
     u = torch.tensor([[0.5, 0.5, 0.5]]).view(1, 3)
-    result = interpolate_grids.interpolate_grid_3d(grid, u)
+    result = interpolate_grids.interpolate_grid_3d(grid, u,
+                                                   matrix=CUBIC_B_SPLINE_MATRIX)
     expected = torch.tensor([31.5])
     assert torch.allclose(result, expected)
 
@@ -132,6 +140,8 @@ def test_interpolate_grid_4d():
            [252, 253, 254, 255]]]]
     ).float()
     u = torch.tensor([0.5, 0.5, 0.5, 0.5]).view(1, 4)
-    result = interpolate_grids.interpolate_grid_4d(grid, u)
+    result = interpolate_grids.interpolate_grid_4d(
+        grid, u, matrix=CUBIC_B_SPLINE_MATRIX
+    )
     expected = torch.tensor([127.5])
     assert torch.allclose(result, expected)

--- a/tests/test_interpolate_pieces.py
+++ b/tests/test_interpolate_pieces.py
@@ -1,26 +1,29 @@
 import torch
 
 from torch_cubic_b_spline_grid import interpolate_pieces
-from torch_cubic_b_spline_grid.constants import CUBIC_B_SPLINE_MATRIX
+from torch_cubic_b_spline_grid._constants import CUBIC_B_SPLINE_MATRIX
 
 
 def test_interpolate_pieces_1d():
     """test that cubic B-spline interpolation results in expected values."""
-    u = 0.5
+    t = 0.5
     points = torch.tensor([-1.5, 5.1, 2.2, 6.8])
     result = interpolate_pieces.interpolate_pieces_1d(
         control_points=points.view(1, 1, 4),  # (b, c, 4)
-        u=torch.tensor([u])
+        t=torch.tensor([t]),
+        matrix=CUBIC_B_SPLINE_MATRIX,
     )
-    expected = torch.tensor([1, u, u ** 2, u ** 3]) @ CUBIC_B_SPLINE_MATRIX @ points
+    expected = torch.tensor([1, t, t ** 2, t ** 3]) @ CUBIC_B_SPLINE_MATRIX @ points
     assert torch.allclose(result, expected)
 
 
 def test_interpolate_pieces_1d_with_batched_queries():
     """test batched evaluation over one 'piece' (set of 4 control points)."""
     pieces = torch.tensor([[0, 1, 2, 3]]).float().view(1, 1, 4)  # (b, c, 4)
-    u = torch.tensor([0, 0.5, 1])  # (b, )
-    result = interpolate_pieces.interpolate_pieces_1d(pieces, u)
+    t = torch.tensor([0, 0.5, 1])  # (b, )
+    result = interpolate_pieces.interpolate_pieces_1d(
+        pieces, t, matrix=CUBIC_B_SPLINE_MATRIX
+    )
 
     # cubic b spline intepolation should be equivalent to linear interpolation
     # for four control points on the same line
@@ -34,8 +37,10 @@ def test_interpolate_pieces_1d_with_batched_pieces_and_queries():
         [[0, 1, 2, 3],
          [2, 3, 4, 5]]
     ).float().view(2, 1, 4)  # (b, c, 4)
-    u = torch.tensor([0.5, 0.5])  # (b, )
-    result = interpolate_pieces.interpolate_pieces_1d(pieces, u)  # (b, c)
+    t = torch.tensor([0.5, 0.5])  # (b, )
+    result = interpolate_pieces.interpolate_pieces_1d(
+        pieces, t, matrix=CUBIC_B_SPLINE_MATRIX
+    )  # (b, c)
 
     # cubic b spline intepolation should be equivalent to linear interpolation
     # for four control points on the same line
@@ -51,8 +56,10 @@ def test_interpolate_pieces_2d():
          [8, 9, 10, 11],
          [12, 13, 14, 15]]
     ).float().view(1, 1, 4, 4)
-    u = torch.tensor([0.5, 0.5]).view(1, 2)
-    result = interpolate_pieces.interpolate_pieces_2d(control_points, u)
+    t = torch.tensor([0.5, 0.5]).view(1, 2)
+    result = interpolate_pieces.interpolate_pieces_2d(
+        control_points, t, matrix=CUBIC_B_SPLINE_MATRIX
+    )
     expected = torch.tensor([7.5])
     assert torch.allclose(result, expected)
 
@@ -77,8 +84,10 @@ def test_interpolate_pieces_3d():
           [56, 57, 58, 59],
           [60, 61, 62, 63]]],
     ).float().view(1, 1, 4, 4, 4)
-    u = torch.tensor([[0.5, 0.5, 0.5]]).view(1, 3)
-    result = interpolate_pieces.interpolate_pieces_3d(control_points, u)
+    t = torch.tensor([[0.5, 0.5, 0.5]]).view(1, 3)
+    result = interpolate_pieces.interpolate_pieces_3d(
+        control_points, t, matrix=CUBIC_B_SPLINE_MATRIX
+    )
     expected = torch.tensor([31.5])
     assert torch.allclose(result, expected)
 
@@ -151,7 +160,9 @@ def test_interpolate_pieces_4d():
            [248, 249, 250, 251],
            [252, 253, 254, 255]]]]
     ).float().view(1, 1, 4, 4, 4, 4)
-    u = torch.tensor([0.5, 0.5, 0.5, 0.5]).view(1, 4)
-    result = interpolate_pieces.interpolate_pieces_4d(control_points, u)
+    t = torch.tensor([0.5, 0.5, 0.5, 0.5]).view(1, 4)
+    result = interpolate_pieces.interpolate_pieces_4d(
+        control_points, t, matrix=CUBIC_B_SPLINE_MATRIX
+    )
     expected = torch.tensor([127.5])
     assert torch.allclose(result, expected)


### PR DESCRIPTION
The existing B-spline interpolation guarantees C2 continuity but does not guarantee that the curve will actually touch all data points. 
Catmull-Rom spline interpolation instead guarantees C1 continuity and that the curve will touch all data points.