### PR TITLE
add automated minibatching in forward call

### DIFF
--- a/src/torch_cubic_spline_grids/b_spline_grids.py
+++ b/src/torch_cubic_spline_grids/b_spline_grids.py
@@ -25,11 +25,14 @@ class CubicBSplineGrid1d(CubicSplineGrid):
     def __init__(
         self,
         resolution: Optional[Union[int, Tuple[int]]] = None,
-        n_channels: int = 1
+        n_channels: int = 1,
+        minibatch_size: int = 1_000_000,
     ):
         if isinstance(resolution, int):
             resolution = tuple([resolution])
-        super().__init__(resolution, n_channels)
+        super().__init__(
+            resolution=resolution, n_channels=n_channels, minibatch_size=minibatch_size
+        )
 
 
 class CubicBSplineGrid2d(CubicSplineGrid):

--- a/src/torch_cubic_spline_grids/catmull_rom_grids.py
+++ b/src/torch_cubic_spline_grids/catmull_rom_grids.py
@@ -25,11 +25,14 @@ class CubicCatmullRomGrid1d(CubicSplineGrid):
     def __init__(
         self,
         resolution: Optional[Union[int, Tuple[int]]] = None,
-        n_channels: int = 1
+        n_channels: int = 1,
+        minibatch_size: int = 1_000_000,
     ):
         if isinstance(resolution, int):
             resolution = tuple([resolution])
-        super().__init__(resolution, n_channels)
+        super().__init__(
+            resolution=resolution, n_channels=n_channels, minibatch_size=minibatch_size
+        )
 
 
 class CubicCatmullRomGrid2d(CubicSplineGrid):

--- a/src/torch_cubic_spline_grids/utils.py
+++ b/src/torch_cubic_spline_grids/utils.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Iterable
 
 import einops
 import torch
@@ -36,7 +36,8 @@ def generate_sample_positions_for_padded_grid_1d(n_samples: int) -> torch.Tensor
     return sample_coordinates
 
 
-def find_control_point_idx_1d(sample_positions: torch.Tensor, query_points: torch.Tensor):
+def find_control_point_idx_1d(sample_positions: torch.Tensor,
+                              query_points: torch.Tensor):
     """Find indices of four control points required for cubic interpolation.
 
     E.g. for sample positions `[0, 1, 2, 3, 4, 5]` and query point `2.5` the control
@@ -130,3 +131,8 @@ def coerce_to_multichannel_grid(grid: torch.Tensor, grid_ndim: int):
     return grid
 
 
+def batch(iterable: Iterable, n: int = 1) -> Iterable[Iterable]:
+    """Split an iterable into batches of constant length."""
+    l = len(iterable)
+    for idx in range(0, l, n):
+        yield iterable[idx:min(idx + n, l)]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
+import einops
 import torch
 
-from torch_cubic_spline_grids.utils import find_control_point_idx_1d
+from torch_cubic_spline_grids.utils import find_control_point_idx_1d, batch
 
 
 def test_find_control_points():
@@ -20,3 +21,19 @@ def test_find_control_points():
     result = find_control_point_idx_1d(sample_positions, torch.tensor([3]))
     expected = torch.tensor([[2, 3, 4, 5]])
     assert torch.allclose(result, expected)
+
+
+def test_batch():
+    """All items should be present in minibatches."""
+    l = [0, 1, 2, 3, 4, 5, 6]
+    minibatches = [minibatch for minibatch in batch(l, n=3)]
+    expected = [[0, 1, 2], [3, 4, 5], [6]]
+    assert minibatches == expected
+
+
+def test_restacking_batch():
+    """Ensure entries get restacked by cat the same way as they are unstacked."""
+    batched_input = torch.rand(size=(10, 3))  # (b, d)
+    minibatches = [minibatch for minibatch in batch(batched_input, n=3)]
+    restacked_minibatches = torch.cat(minibatches, dim=0)
+    assert torch.allclose(batched_input, restacked_minibatches)


### PR DESCRIPTION
- minibatch size can be set in constructor
- this can help to avoid out-of-memory errors when interpolating large numbers of coordinates on 2D/3D/4D grids as each interpolant requires a [4] * grid_ndim grid of control points for interpolation