### PR TITLE
Introduce `monotonicity` parameter to the modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,16 +19,12 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.118
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.10
     hooks:
       - id: ruff
         args: [--fix]
-
-  - repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-      - id: black
+      - id: ruff-format
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.10.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest>=6.0", "pytest-cov"]
 dev = [
-    "black",
     "ipython",
     "mypy",
     "pdbpp",
@@ -72,6 +71,8 @@ source = "vcs"
 [tool.ruff]
 line-length = 88
 target-version = "py38"
+
+[tool.ruff.lint]
 extend-select = [
     "E",    # style errors
     "F",    # flakes
@@ -84,7 +85,6 @@ extend-select = [
     "B",    # flake8-bugbear
     "A001", # flake8-builtins
     "RUF",  # ruff-specific rules
-    "M001", # Unused noqa directive
 ]
 extend-ignore = [
     "D100", # Missing docstring in public module
@@ -96,12 +96,20 @@ extend-ignore = [
     "D416", # Section name should end with a colon
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = ["D"]
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+
+[tool.ruff.format]
+# Prefer single quotes over double quotes.
+quote-style = "single"
 
 # https://docs.pytest.org/en/6.2.x/customize.html
 [tool.pytest.ini_options]
 minversion = "6.0"
+pythonpath = "src"
 testpaths = ["tests"]
 filterwarnings = [
     "error",

--- a/src/torch_cubic_spline_grids/__init__.py
+++ b/src/torch_cubic_spline_grids/__init__.py
@@ -1,13 +1,14 @@
-"""Cubic B-spline interpolation on multidimensional grids in PyTorch"""
+"""Cubic B-spline interpolation on multidimensional grids in PyTorch."""
+
 from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = version("torch-cubic-b-spline-grid")
+    __version__ = version('torch-cubic-b-spline-grid')
 except PackageNotFoundError:
-    __version__ = "uninstalled"
+    __version__ = 'uninstalled'
 
-__author__ = "Alister Burt"
-__email__ = "alisterburt@gmail.com"
+__author__ = 'Alister Burt'
+__email__ = 'alisterburt@gmail.com'
 
 from .b_spline_grids import (
     CubicBSplineGrid1d,
@@ -15,7 +16,6 @@ from .b_spline_grids import (
     CubicBSplineGrid3d,
     CubicBSplineGrid4d,
 )
-
 from .catmull_rom_grids import (
     CubicCatmullRomGrid1d,
     CubicCatmullRomGrid2d,
@@ -24,12 +24,12 @@ from .catmull_rom_grids import (
 )
 
 __all__ = [
-    CubicBSplineGrid1d,
-    CubicBSplineGrid2d,
-    CubicBSplineGrid3d,
-    CubicBSplineGrid4d,
-    CubicCatmullRomGrid1d,
-    CubicCatmullRomGrid2d,
-    CubicCatmullRomGrid3d,
-    CubicCatmullRomGrid4d,
+    'CubicBSplineGrid1d',
+    'CubicBSplineGrid2d',
+    'CubicBSplineGrid3d',
+    'CubicBSplineGrid4d',
+    'CubicCatmullRomGrid1d',
+    'CubicCatmullRomGrid2d',
+    'CubicCatmullRomGrid3d',
+    'CubicCatmullRomGrid4d',
 ]

--- a/src/torch_cubic_spline_grids/_base_cubic_grid.py
+++ b/src/torch_cubic_spline_grids/_base_cubic_grid.py
@@ -4,7 +4,11 @@ from typing import Callable, Optional, Tuple
 import einops
 import torch
 
-from torch_cubic_spline_grids.utils import batch, coerce_to_multichannel_grid
+from torch_cubic_spline_grids.utils import (
+    MonotonicityType,
+    batch,
+    coerce_to_multichannel_grid,
+)
 
 
 class CubicSplineGrid(torch.nn.Module):
@@ -23,11 +27,11 @@ class CubicSplineGrid(torch.nn.Module):
         resolution: Optional[Tuple[int, ...]] = None,
         n_channels: int = 1,
         minibatch_size: int = 1_000_000,
-        monotonicity: Optional[str] = None,
+        monotonicity: Optional[MonotonicityType] = None,
     ):
         super().__init__()
         if resolution is None:
-            resolution = [2] * self.ndim
+            resolution = (2,) * self.ndim
         grid_shape = (n_channels, *resolution)
         self.data = torch.zeros(size=grid_shape)
         self._minibatch_size = minibatch_size

--- a/src/torch_cubic_spline_grids/b_spline_grids.py
+++ b/src/torch_cubic_spline_grids/b_spline_grids.py
@@ -11,6 +11,7 @@ from torch_cubic_spline_grids.interpolate_grids import (
     interpolate_grid_3d as _interpolate_grid_3d,
     interpolate_grid_4d as _interpolate_grid_4d,
 )
+from torch_cubic_spline_grids.utils import MonotonicityType
 
 CoordinateLike = Union[float, Sequence[float], torch.Tensor]
 
@@ -30,7 +31,7 @@ class CubicBSplineGrid1d(_CubicBSplineGrid):
         resolution: Optional[Union[int, Tuple[int]]] = None,
         n_channels: int = 1,
         minibatch_size: int = 1_000_000,
-        monotonicity: Optional[str] = None,
+        monotonicity: Optional[MonotonicityType] = None,
     ):
         if isinstance(resolution, int):
             resolution = (resolution,)

--- a/src/torch_cubic_spline_grids/b_spline_grids.py
+++ b/src/torch_cubic_spline_grids/b_spline_grids.py
@@ -1,16 +1,16 @@
 from functools import partial
-from typing import Tuple, Callable, Union, Sequence, Optional
+from typing import Callable, Optional, Sequence, Tuple, Union
 
 import torch
 
 from torch_cubic_spline_grids._base_cubic_grid import CubicSplineGrid
+from torch_cubic_spline_grids._constants import CUBIC_B_SPLINE_MATRIX
 from torch_cubic_spline_grids.interpolate_grids import (
     interpolate_grid_1d as _interpolate_grid_1d,
     interpolate_grid_2d as _interpolate_grid_2d,
     interpolate_grid_3d as _interpolate_grid_3d,
     interpolate_grid_4d as _interpolate_grid_4d,
 )
-from torch_cubic_spline_grids._constants import CUBIC_B_SPLINE_MATRIX
 
 CoordinateLike = Union[float, Sequence[float], torch.Tensor]
 
@@ -21,6 +21,7 @@ class _CubicBSplineGrid(CubicSplineGrid):
 
 class CubicBSplineGrid1d(_CubicBSplineGrid):
     """Continuous parametrisation of a 1D space with a specific resolution."""
+
     ndim: int = 1
     _interpolation_function: Callable = partial(_interpolate_grid_1d)
 
@@ -29,27 +30,34 @@ class CubicBSplineGrid1d(_CubicBSplineGrid):
         resolution: Optional[Union[int, Tuple[int]]] = None,
         n_channels: int = 1,
         minibatch_size: int = 1_000_000,
+        monotonicity: Optional[str] = None,
     ):
         if isinstance(resolution, int):
-            resolution = tuple([resolution])
+            resolution = (resolution,)
         super().__init__(
-            resolution=resolution, n_channels=n_channels, minibatch_size=minibatch_size
+            resolution=resolution,
+            n_channels=n_channels,
+            minibatch_size=minibatch_size,
+            monotonicity=monotonicity,
         )
 
 
 class CubicBSplineGrid2d(_CubicBSplineGrid):
     """Continuous parametrisation of a 2D space with a specific resolution."""
+
     ndim: int = 2
     _interpolation_function: Callable = partial(_interpolate_grid_2d)
 
 
 class CubicBSplineGrid3d(_CubicBSplineGrid):
     """Continuous parametrisation of a 3D space with a specific resolution."""
+
     ndim: int = 3
     _interpolation_function: Callable = partial(_interpolate_grid_3d)
 
 
 class CubicBSplineGrid4d(_CubicBSplineGrid):
     """Continuous parametrisation of a 4D space with a specific resolution."""
+
     ndim: int = 4
     _interpolation_function: Callable = partial(_interpolate_grid_4d)

--- a/src/torch_cubic_spline_grids/catmull_rom_grids.py
+++ b/src/torch_cubic_spline_grids/catmull_rom_grids.py
@@ -1,16 +1,16 @@
 from functools import partial
-from typing import Tuple, Callable, Union, Sequence, Optional
+from typing import Callable, Optional, Sequence, Tuple, Union
 
 import torch
 
 from torch_cubic_spline_grids._base_cubic_grid import CubicSplineGrid
+from torch_cubic_spline_grids._constants import CUBIC_CATMULL_ROM_MATRIX
 from torch_cubic_spline_grids.interpolate_grids import (
     interpolate_grid_1d as _interpolate_grid_1d,
     interpolate_grid_2d as _interpolate_grid_2d,
     interpolate_grid_3d as _interpolate_grid_3d,
     interpolate_grid_4d as _interpolate_grid_4d,
 )
-from torch_cubic_spline_grids._constants import CUBIC_CATMULL_ROM_MATRIX
 
 CoordinateLike = Union[float, Sequence[float], torch.Tensor]
 
@@ -21,6 +21,7 @@ class _CubicCatmullRomGrid(CubicSplineGrid):
 
 class CubicCatmullRomGrid1d(_CubicCatmullRomGrid):
     """Continuous parametrisation of a 1D space with a specific resolution."""
+
     ndim: int = 1
     _interpolation_function: Callable = partial(_interpolate_grid_1d)
 
@@ -29,27 +30,34 @@ class CubicCatmullRomGrid1d(_CubicCatmullRomGrid):
         resolution: Optional[Union[int, Tuple[int]]] = None,
         n_channels: int = 1,
         minibatch_size: int = 1_000_000,
+        monotonicity: Optional[str] = None,
     ):
         if isinstance(resolution, int):
-            resolution = tuple([resolution])
+            resolution = (resolution,)
         super().__init__(
-            resolution=resolution, n_channels=n_channels, minibatch_size=minibatch_size
+            resolution=resolution,
+            n_channels=n_channels,
+            minibatch_size=minibatch_size,
+            monotonicity=monotonicity,
         )
 
 
 class CubicCatmullRomGrid2d(_CubicCatmullRomGrid):
     """Continuous parametrisation of a 2D space with a specific resolution."""
+
     ndim: int = 2
     _interpolation_function: Callable = partial(_interpolate_grid_2d)
 
 
 class CubicCatmullRomGrid3d(_CubicCatmullRomGrid):
     """Continuous parametrisation of a 3D space with a specific resolution."""
+
     ndim: int = 3
     _interpolation_function: Callable = partial(_interpolate_grid_3d)
 
 
 class CubicCatmullRomGrid4d(_CubicCatmullRomGrid):
     """Continuous parametrisation of a 4D space with a specific resolution."""
+
     ndim: int = 4
     _interpolation_function: Callable = partial(_interpolate_grid_4d)

--- a/src/torch_cubic_spline_grids/catmull_rom_grids.py
+++ b/src/torch_cubic_spline_grids/catmull_rom_grids.py
@@ -11,6 +11,7 @@ from torch_cubic_spline_grids.interpolate_grids import (
     interpolate_grid_3d as _interpolate_grid_3d,
     interpolate_grid_4d as _interpolate_grid_4d,
 )
+from torch_cubic_spline_grids.utils import MonotonicityType
 
 CoordinateLike = Union[float, Sequence[float], torch.Tensor]
 
@@ -30,7 +31,7 @@ class CubicCatmullRomGrid1d(_CubicCatmullRomGrid):
         resolution: Optional[Union[int, Tuple[int]]] = None,
         n_channels: int = 1,
         minibatch_size: int = 1_000_000,
-        monotonicity: Optional[str] = None,
+        monotonicity: Optional[MonotonicityType] = None,
     ):
         if isinstance(resolution, int):
             resolution = (resolution,)

--- a/src/torch_cubic_spline_grids/interpolate_pieces.py
+++ b/src/torch_cubic_spline_grids/interpolate_pieces.py
@@ -1,13 +1,12 @@
 """Interpolate 'pieces' for piecewise uniform cubic B-spline interpolation."""
-import torch
-import einops
 
-from ._constants import CUBIC_B_SPLINE_MATRIX, CUBIC_CATMULL_ROM_MATRIX
+import einops
+import torch
 
 
 def interpolate_pieces_1d(
     control_points: torch.Tensor, t: torch.Tensor, matrix: torch.Tensor
-):
+) -> torch.Tensor:
     """Batched uniform 1D cubic spline interpolation.
 
     ```
@@ -34,7 +33,7 @@ def interpolate_pieces_1d(
     interpolated: torch.Tensor
         `(b, c)` array of per-channel interpolants of `control_points` at `u`.
     """
-    t = einops.rearrange([t ** 0, t, t ** 2, t ** 3], 'u b -> b 1 1 u')
+    t = einops.rearrange([t**0, t, t**2, t**3], 'u b -> b 1 1 u')
     control_points = einops.rearrange(control_points, 'b c p -> b c p 1')
     interpolated = t @ matrix @ control_points
     return einops.rearrange(interpolated, 'b c 1 1 -> b c')
@@ -42,7 +41,7 @@ def interpolate_pieces_1d(
 
 def interpolate_pieces_2d(
     control_points: torch.Tensor, t: torch.Tensor, matrix: torch.Tensor
-):
+) -> torch.Tensor:
     """Batched uniform 2D cubic B-spline interpolation.
 
     Parameters
@@ -51,8 +50,8 @@ def interpolate_pieces_2d(
         `(b, c, 4, 4)` batch of 2D multichannel grids of uniformly spaced control
         points `[p0, p1, p2, p3]` for cubic B-spline interpolation.
     t: torch.Tensor
-        `(b, 2)` batch of values in the range `[0, 1]` defining the position of 2D points
-        to be interpolated within the interval `[p1, p2]` along dim 1 and 2 of
+        `(b, 2)` batch of values in the range `[0, 1]` defining the position of 2D
+        points to be interpolated within the interval `[p1, p2]` along dim 1 and 2 of
         the 2D grid of control points.
     matrix: torch.Tensor
         `(4, 4)` characteristic matrix for the spline.
@@ -81,7 +80,7 @@ def interpolate_pieces_2d(
 
 def interpolate_pieces_3d(
     control_points: torch.Tensor, t: torch.Tensor, matrix: torch.Tensor
-):
+) -> torch.Tensor:
     """Batched uniform 3D cubic B-spline interpolation.
 
     Parameters
@@ -121,7 +120,7 @@ def interpolate_pieces_3d(
 
 def interpolate_pieces_4d(
     control_points: torch.Tensor, t: torch.Tensor, matrix: torch.Tensor
-):
+) -> torch.Tensor:
     """Batched 4D cubic B-spline interpolation.
 
     Parameters

--- a/src/torch_cubic_spline_grids/pad_grids.py
+++ b/src/torch_cubic_spline_grids/pad_grids.py
@@ -2,7 +2,7 @@ import einops
 import torch
 
 
-def pad_grid_1d(grid: torch.Tensor):
+def pad_grid_1d(grid: torch.Tensor) -> torch.Tensor:
     """Pad in the last dimension according to local gradients.
 
     e.g. [0, 1, 2] -> [-1, 0, 1, 2, 3]

--- a/src/torch_cubic_spline_grids/utils.py
+++ b/src/torch_cubic_spline_grids/utils.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Callable, Iterable, Tuple
+from typing import Callable, Iterable, Literal, Tuple
 
 import einops
 import torch
@@ -41,7 +41,7 @@ def generate_sample_positions_for_padded_grid_1d(
 
 def find_control_point_idx_1d(
     sample_positions: torch.Tensor, query_points: torch.Tensor
-):
+) -> torch.Tensor:
     """Find indices of four control points required for cubic interpolation.
 
     E.g. for sample positions `[0, 1, 2, 3, 4, 5]` and query point `2.5` the control
@@ -124,7 +124,7 @@ def interpolants_to_interpolation_data_1d(
     return control_point_idx, interpolation_coordinate
 
 
-def coerce_to_multichannel_grid(grid: torch.Tensor, grid_ndim: int):
+def coerce_to_multichannel_grid(grid: torch.Tensor, grid_ndim: int) -> torch.Tensor:
     """If missing, add a channel dimension to a multidimensional grid.
 
     e.g. for a 2D (h, w) grid
@@ -140,7 +140,12 @@ def coerce_to_multichannel_grid(grid: torch.Tensor, grid_ndim: int):
     return grid
 
 
-def transform_to_monotonic_nd(tensor: torch.Tensor, ndims: int, monotonicity: str):
+MonotonicityType = Literal['increasing', 'decreasing']
+
+
+def transform_to_monotonic_nd(
+    tensor: torch.Tensor, ndims: int, monotonicity: MonotonicityType
+) -> torch.Tensor:
     """Transform tensor values, so they are monotonic across dimensions.
 
     Parameters
@@ -151,7 +156,7 @@ def transform_to_monotonic_nd(tensor: torch.Tensor, ndims: int, monotonicity: st
         the number of the dimensions counting from the last to the first, for which
         elements should be monotonic.
     monotonicity: str
-        Either 'nodecreasing' or 'nonincreasing'.
+        Either 'decreasing' or 'increasing'.
 
     Returns
     -------
@@ -160,9 +165,9 @@ def transform_to_monotonic_nd(tensor: torch.Tensor, ndims: int, monotonicity: st
     """
     monotonicity_function: Callable
 
-    if monotonicity == 'nondecreasing':
+    if monotonicity == 'increasing':
         monotonicity_function = torch.cummax
-    elif monotonicity == 'nonincreasing':
+    elif monotonicity == 'decreasing':
         monotonicity_function = torch.cummin
     elif monotonicity != '':
         raise ValueError(f'Unsupported monotonicity type "{monotonicity}" specified.')

--- a/tests/test_grid_optimisation.py
+++ b/tests/test_grid_optimisation.py
@@ -1,6 +1,5 @@
 import einops
 import torch
-
 from torch_cubic_spline_grids import (
     CubicBSplineGrid1d,
     CubicBSplineGrid2d,
@@ -21,7 +20,7 @@ def test_1d_grid_optimisation():
         return y
 
     optimiser = torch.optim.SGD(lr=0.1, params=grid.parameters())
-    for i in range(5000):
+    for _i in range(5000):
         x = torch.rand(size=(n_observations_per_iteration,))
         observations = f(x, add_noise=True)
         prediction = grid(x).squeeze()
@@ -37,6 +36,40 @@ def test_1d_grid_optimisation():
     assert mean_absolute_error.item() < 0.02
 
 
+def test_1d_grid_optimization_non_increasing():
+    grid_resolution = 8
+    n_observations_per_iteration = 100
+    grid = CubicBSplineGrid1d(
+        resolution=grid_resolution, n_channels=1, monotonicity='nonincreasing'
+    )
+
+    def f(x: torch.Tensor, add_noise: bool = False):
+        y = torch.exp(-5 * x)
+        if add_noise is True:
+            y += torch.normal(mean=torch.zeros(len(y)), std=0.3)
+        return y
+
+    optimiser = torch.optim.SGD(lr=0.1, params=grid.parameters())
+    for _i in range(5000):
+        x = torch.rand(size=(n_observations_per_iteration,))
+        observations = f(x, add_noise=True)
+        prediction = grid(x).squeeze()
+        loss = torch.mean(torch.abs(prediction - observations))
+        loss.backward()
+        optimiser.step()
+        optimiser.zero_grad()
+
+    x = torch.linspace(0, 1, steps=100)
+    ground_truth = f(x)
+    prediction = grid(x).squeeze()
+    mean_absolute_error = torch.mean(torch.abs(prediction - ground_truth))
+    assert mean_absolute_error.item() < 0.02
+
+    eps = torch.finfo(prediction.dtype).eps
+    non_increasing = torch.diff(prediction, dim=-1) <= eps
+    assert non_increasing.all().item()
+
+
 def test_2d_grid_optimisation():
     grid_resolution = (3, 3)
     n_observations_per_iteration = 100
@@ -44,13 +77,13 @@ def test_2d_grid_optimisation():
 
     def f(x: torch.Tensor, add_noise: bool = False):
         centered = x - 0.5
-        y = torch.sqrt(torch.sum(centered ** 2, dim=-1))  # (x**2 + y**2) ** 0.5
+        y = torch.sqrt(torch.sum(centered**2, dim=-1))  # (x**2 + y**2) ** 0.5
         if add_noise is True:
             y += torch.normal(mean=torch.zeros(len(y)), std=0.3)
         return y
 
     optimiser = torch.optim.SGD(lr=0.3, params=grid.parameters())
-    for i in range(1000):
+    for _i in range(1000):
         x = torch.rand(size=(n_observations_per_iteration, 2))
         observations = f(x, add_noise=True)
         prediction = grid(x).squeeze()
@@ -75,13 +108,13 @@ def test_3d_grid_optimisation():
 
     def f(x: torch.Tensor, add_noise: bool = False):
         centered = x - 0.5
-        y = torch.sqrt(torch.sum(centered ** 2, dim=-1))  # (x**2 + y**2 + z**2) ** 0.5
+        y = torch.sqrt(torch.sum(centered**2, dim=-1))  # (x**2 + y**2 + z**2) ** 0.5
         if add_noise is True:
             y += torch.normal(mean=torch.zeros(len(y)), std=0.3)
         return y
 
     optimiser = torch.optim.SGD(lr=0.3, params=grid.parameters())
-    for i in range(1000):
+    for _i in range(1000):
         x = torch.rand(size=(n_observations_per_iteration, 3))
         observations = f(x, add_noise=True)
         prediction = grid(x).squeeze()
@@ -106,13 +139,13 @@ def test_4d_grid_optimisation():
 
     def f(x: torch.Tensor, add_noise: bool = False):
         centered = x - 0.5
-        y = torch.sqrt(torch.sum(centered ** 2, dim=-1))
+        y = torch.sqrt(torch.sum(centered**2, dim=-1))
         if add_noise is True:
             y += torch.normal(mean=torch.zeros(len(y)), std=0.3)
         return y
 
     optimiser = torch.optim.SGD(lr=0.9, params=grid.parameters())
-    for i in range(1000):
+    for _i in range(1000):
         x = torch.rand(size=(n_observations_per_iteration, 4))
         observations = f(x, add_noise=True)
         prediction = grid(x).squeeze()


### PR DESCRIPTION
This patch does introduces monotonicity parameter (non-decreasing or non-increasing), which enforces the monotoicity of the control points in the grids. This fine control allows to yield non-linear monotonic dependencies. By default behaviour is preserved and monotonicity is not enforced.

Also this patch updates formatting/linting: ruff version is updated, black is dropped (they are doing the same and override output of each other, which is very annoying). The preference is given to the ruff since it was the first in the `.pre-commit-config.yaml`.