### PR TITLE
Replace partial from functools with staticmethod

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
       - id: check-docstring-first
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: debug-statements
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.10
@@ -32,7 +33,7 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.15.0
     hooks:
       - id: mypy
         files: "^src/"

--- a/src/torch_cubic_spline_grids/b_spline_grids.py
+++ b/src/torch_cubic_spline_grids/b_spline_grids.py
@@ -1,4 +1,3 @@
-from functools import partial
 from typing import Callable, Optional, Sequence, Tuple, Union
 
 import torch
@@ -24,7 +23,7 @@ class CubicBSplineGrid1d(_CubicBSplineGrid):
     """Continuous parametrisation of a 1D space with a specific resolution."""
 
     ndim: int = 1
-    _interpolation_function: Callable = partial(_interpolate_grid_1d)
+    _interpolation_function: Callable = staticmethod(_interpolate_grid_1d)
 
     def __init__(
         self,
@@ -47,18 +46,18 @@ class CubicBSplineGrid2d(_CubicBSplineGrid):
     """Continuous parametrisation of a 2D space with a specific resolution."""
 
     ndim: int = 2
-    _interpolation_function: Callable = partial(_interpolate_grid_2d)
+    _interpolation_function: Callable = staticmethod(_interpolate_grid_2d)
 
 
 class CubicBSplineGrid3d(_CubicBSplineGrid):
     """Continuous parametrisation of a 3D space with a specific resolution."""
 
     ndim: int = 3
-    _interpolation_function: Callable = partial(_interpolate_grid_3d)
+    _interpolation_function: Callable = staticmethod(_interpolate_grid_3d)
 
 
 class CubicBSplineGrid4d(_CubicBSplineGrid):
     """Continuous parametrisation of a 4D space with a specific resolution."""
 
     ndim: int = 4
-    _interpolation_function: Callable = partial(_interpolate_grid_4d)
+    _interpolation_function: Callable = staticmethod(_interpolate_grid_4d)

--- a/src/torch_cubic_spline_grids/catmull_rom_grids.py
+++ b/src/torch_cubic_spline_grids/catmull_rom_grids.py
@@ -1,4 +1,3 @@
-from functools import partial
 from typing import Callable, Optional, Sequence, Tuple, Union
 
 import torch
@@ -24,7 +23,7 @@ class CubicCatmullRomGrid1d(_CubicCatmullRomGrid):
     """Continuous parametrisation of a 1D space with a specific resolution."""
 
     ndim: int = 1
-    _interpolation_function: Callable = partial(_interpolate_grid_1d)
+    _interpolation_function: Callable = staticmethod(_interpolate_grid_1d)
 
     def __init__(
         self,
@@ -47,18 +46,18 @@ class CubicCatmullRomGrid2d(_CubicCatmullRomGrid):
     """Continuous parametrisation of a 2D space with a specific resolution."""
 
     ndim: int = 2
-    _interpolation_function: Callable = partial(_interpolate_grid_2d)
+    _interpolation_function: Callable = staticmethod(_interpolate_grid_2d)
 
 
 class CubicCatmullRomGrid3d(_CubicCatmullRomGrid):
     """Continuous parametrisation of a 3D space with a specific resolution."""
 
     ndim: int = 3
-    _interpolation_function: Callable = partial(_interpolate_grid_3d)
+    _interpolation_function: Callable = staticmethod(_interpolate_grid_3d)
 
 
 class CubicCatmullRomGrid4d(_CubicCatmullRomGrid):
     """Continuous parametrisation of a 4D space with a specific resolution."""
 
     ndim: int = 4
-    _interpolation_function: Callable = partial(_interpolate_grid_4d)
+    _interpolation_function: Callable = staticmethod(_interpolate_grid_4d)


### PR DESCRIPTION
This patch addresses an issue with a modified behaviour of the `functools.partial` implementation in the Python 3.13, as suggested wrapping dynamically assigned methods into `staticmethod` decorator. This patch completely removes usage of `functools.partial` and moves partial functions into regular instance methods.

Also this patch addresses minor mypy complains of duplicated property declarations (`n_channels` and `resolution`).

Addresses #28 